### PR TITLE
Allow custom banner image

### DIFF
--- a/build/build-compile.xml
+++ b/build/build-compile.xml
@@ -107,8 +107,9 @@
 		<!-- Create the war file! -->
 		<war compress="${compression-enabled}" level="9" warfile="${war-file-name}" webxml="${web-inf}/web.xml">
 			<classes dir="${class-dir}" />
-			<fileset dir="WebContent" excludes="**/*.scss,**/context.template"/>
+			<fileset dir="WebContent" excludes="**/*.scss,**/context.template,**/starlogo.png"/>
 			<lib dir="${starcomlib}"/>
+			<zipfileset file="${Web.Image.Banner}" fullpath="images/starlogo.png" />
 		</war>
 	</target>
 </project>

--- a/build/default.properties
+++ b/build/default.properties
@@ -75,6 +75,7 @@ Web.URL: https://${Web.Address}/${Web.BaseDirectory}/
 Web.DB.User: ${DB.User}
 Web.DB.Pass: ${DB.Pass}
 Web.DB.Url: ${DB.Url}
+Web.Image.Banner: WebContent/images/starlogo.png
 
 ALLOW_TESTING: false
 TEST_COMMUNITY_ID: -1

--- a/example.properties
+++ b/example.properties
@@ -36,9 +36,12 @@ Email.Port: 25
 Email.Smtp: smtp.example.com
 Email.User: noreply@example.com
 
+# Path to a custom logo that will be used on website
+# Must be a 300x70 PNG image
+Web.Image.Banner: WebContent/images/starlogo.png
+
 # change this to the directory in which you installed tomcat 7
 tomcat-dir: /project/tomcat/apache-tomcat-7
 
 # Set to your webapps dir. It should be something like tomcat-dir/webapps
 web-home: /project/tomcat-webapps/webapps
-


### PR DESCRIPTION
This allows a StarExec instance to set a custom banner image to display at the top of each webpage.

For developers, this will make it more obvious when using a development instance vs production. For production instances, this will allow the opportunity to use some custom branding (ie: displaying the university logo alongside the StarExec branding).

![StarExec instance with custom banner image](https://user-images.githubusercontent.com/251545/36555835-c3c667f8-17c8-11e8-921d-edc40ec6089a.png)
