### PR TITLE
Allow supplying `machine-specs.txt`

### DIFF
--- a/build/build-compile.xml
+++ b/build/build-compile.xml
@@ -110,6 +110,7 @@
 			<fileset dir="WebContent" excludes="**/*.scss,**/context.template,**/starlogo.png"/>
 			<lib dir="${starcomlib}"/>
 			<zipfileset file="${Web.Image.Banner}" fullpath="images/starlogo.png" />
+			<zipfileset file="${Cluster.MachineSpecs}" fullpath="public/machine-specs.txt" />
 		</war>
 	</target>
 </project>

--- a/build/default.properties
+++ b/build/default.properties
@@ -43,6 +43,7 @@ Cluster.DB.Url: ${DB.Url}
 Cluster.UpdatePeriod: 600
 Cluster.UserOne: sandbox
 Cluster.UserTwo: sandbox2
+Cluster.MachineSpecs:
 
 Email.Contact: noreply@example.com
 Email.Smtp:

--- a/example.properties
+++ b/example.properties
@@ -30,6 +30,9 @@ DB.Pool.Min: 20
 # to report back as job pairs finish.
 Cluster.DB.Url: db.example.com
 
+# Text file describing machine specs of cluster nodes
+Cluster.MachineSpecs:
+
 # Email credentials for outgoing messages
 Email.Contact: starexec-admin@example.com
 Email.Port: 25


### PR DESCRIPTION
This allows a path to a text file supplied in config to be included in the WAR as `machine-specs.txt`

This is a follow-up to adfe81498c110f061f2bb1898524ac58be47e708. Instead of copying `machine-specs.txt` into the repository before build, this allows the text file to be kept _out_ of the repository, and referenced by the config.