### PR TITLE
Better logging when JobPair cannot be found during submit

### DIFF
--- a/src/org/starexec/data/database/JobPairs.java
+++ b/src/org/starexec/data/database/JobPairs.java
@@ -1165,10 +1165,12 @@ public class JobPairs {
 				jp.getPrimarySolver().getConfigurations().get(0).setName(results.getString("config_name"));
 				jp.getStages().get(0).setConfiguration(jp.getPrimarySolver().getConfigurations().get(0));
 				return jp;
+			} else {
+				log.warn("getPair", "Pair not found: " + pairId);
 			}
 			Common.safeClose(results);
 		} catch (Exception e) {
-			log.error(e.getMessage(), e);
+			log.error("getPair", e);
 		} finally {
 			Common.safeClose(con);
 			Common.safeClose(procedure);

--- a/src/org/starexec/jobs/JobManager.java
+++ b/src/org/starexec/jobs/JobManager.java
@@ -339,7 +339,7 @@ public abstract class JobManager {
 
 				}
 				if (curLoops > maxLoops) {
-					log.warn("forcibly breaking out of JobManager.submitJobs()-- max loops exceeded");
+					log.warn("submitJobs" "forcibly breaking out of JobManager.submitJobs()-- max loops exceeded");
 					break;
 				}
 
@@ -453,7 +453,7 @@ public abstract class JobManager {
 								continue;
 							}
 						} catch (SQLException e) {
-							log.error("Database error while trying to get broken bench dependencies.", e);
+							log.error("submitJobs", "Database error while trying to get broken bench dependencies.", e);
 							// submit the pair anyway, if there are broken bench dependencies then we will get a
 							// submit_failed status.
 						}
@@ -464,7 +464,7 @@ public abstract class JobManager {
 							// twice.
 							StatusCode statusOfPair = JobPairs.getPair(pair.getId()).getStatus().getCode();
 							if (statusOfPair != StatusCode.STATUS_PENDING_SUBMIT) {
-								log.warn("Pair with id=" + pair.getId() +
+								log.warn("submitJobs", "Pair with id=" + pair.getId() +
 								         " was caught attempting to be submitted again.");
 								continue;
 							}
@@ -497,12 +497,10 @@ public abstract class JobManager {
 							}
 							queueSize++;
 						} catch (BenchmarkDependencyMissingException e) {
-							log.error("submitJobs() received exception " + e.getMessage());
-							log.error("setting pair with following ID to benchmark fail " + pair.getId());
+							log.error("submitJobs", "ERROR_BENCHMARK for pair: " + pair.getId(), e);
 							JobPairs.setStatusForPairAndStages(pair.getId(), StatusCode.ERROR_BENCHMARK.getVal());
 						} catch (Exception e) {
-							log.error("submitJobs() received exception " + e.getMessage(), e);
-							log.error("setting pair with following ID to submit_fail " + pair.getId());
+							log.error("submitJobs", "ERROR_SUBMIT_FAIL for pair: " + pair.getId(), e);
 							JobPairs.setStatusForPairAndStages(pair.getId(), StatusCode.ERROR_SUBMIT_FAIL.getVal());
 						}
 					}
@@ -510,7 +508,7 @@ public abstract class JobManager {
 			} // end looping until schedule is empty or we have submitted enough job pairs
 
 		} catch (Exception e) {
-			log.error(e.getMessage(), e);
+			log.error("submitJobs", e);
 		}
 
 	} // end submitJobs()

--- a/src/org/starexec/jobs/JobManager.java
+++ b/src/org/starexec/jobs/JobManager.java
@@ -339,7 +339,8 @@ public abstract class JobManager {
 
 				}
 				if (curLoops > maxLoops) {
-					log.warn("submitJobs" "forcibly breaking out of JobManager.submitJobs()-- max loops exceeded");
+					log.warn("submitJobs",
+							"forcibly breaking out of JobManager.submitJobs()-- max loops exceeded");
 					break;
 				}
 
@@ -459,13 +460,20 @@ public abstract class JobManager {
 						}
 
 						try {
-
-							// Check to make sure the pair is still pending submit to prevent pairs being submitted
-							// twice.
-							StatusCode statusOfPair = JobPairs.getPair(pair.getId()).getStatus().getCode();
+							/* Check to make sure the pair is still pending submit
+							 * to prevent pairs being submitted twice. */
+							final JobPair jp = JobPairs.getPair(pair.getId());
+							if (jp == null) {
+								log.warn("submitJobs",
+										"Cannot get details for pair: " + pair.getId());
+								continue;
+							}
+							StatusCode statusOfPair = jp.getStatus().getCode();
 							if (statusOfPair != StatusCode.STATUS_PENDING_SUBMIT) {
-								log.warn("submitJobs", "Pair with id=" + pair.getId() +
-								         " was caught attempting to be submitted again.");
+								log.warn("submitJobs",
+										"Pair was caught attempting to be submitted again."
+										+ "\n\tJobPair: " + pair.getId()
+										+ "\n\tStatus:  " + statusOfPair);
 								continue;
 							}
 


### PR DESCRIPTION
```text
Level: ERROR
(org.starexec.jobs.JobManager) - submitJobs() received exception null
Stack Trace:
java.lang.NullPointerException
        at org.starexec.jobs.JobManager.submitJobs(JobManager.java:465)
        at org.starexec.jobs.JobManager.checkPendingJobs(JobManager.java:114)
        at org.starexec.app.PeriodicTasks$3.dorun(PeriodicTasks.java:141)
        at org.starexec.util.RobustRunnable.run(RobustRunnable.java:23)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```