### PR TITLE
Fix subspace panels

### DIFF
--- a/WebContent/js/details/job.js
+++ b/WebContent/js/details/job.js
@@ -1480,8 +1480,10 @@ function getSolverTableInitializer() {
 
 		panelTableInitializer["fnServerData"] = fnShortStatsPaginationHandler;
 		window.getPanelTableInitializer = function(jobId, spaceId) {
-			panelTableInitializer["sAjaxSource"] = getPaginationUrl(spaceId);
-			return panelTableInitializer;
+			var data = {};
+			$.extend(data, panelTableInitializer);
+			data["sAjaxSource"] = getPaginationUrl(spaceId);
+			return data;
 		}
 	}
 

--- a/WebContent/js/details/job.js
+++ b/WebContent/js/details/job.js
@@ -1480,8 +1480,7 @@ function getSolverTableInitializer() {
 
 		panelTableInitializer["fnServerData"] = fnShortStatsPaginationHandler;
 		window.getPanelTableInitializer = function(jobId, spaceId) {
-			var data = {};
-			$.extend(data, panelTableInitializer);
+			var data = $.extend({}, panelTableInitializer); // deep copy
 			data["sAjaxSource"] = getPaginationUrl(spaceId);
 			return data;
 		}


### PR DESCRIPTION
Perviously there was only one `panelTableInitializer` object. `window.getPanelTableInitializer` would set the `sAjaxSource` property of the single object and return a reference to it. This is apparently a problem, as these objects seem to persist even after the panel has been created.

By overriding `sAjaxSource` each time, we end up giving all subspace summaries the same data source, which is obviously a problem.

We can fix this by creating a duplicate of `panelTableInitializer` each time this function is called.

https://github.com/StarExec/StarExec/blob/ca6b4be2b9641d8eceaa4f7e43b04784b8c69b0f/WebContent/js/details/job.js#L1162-L1168