### PR TITLE
Provide helpful log when public user is missing

### DIFF
--- a/src/org/starexec/app/Starexec.java
+++ b/src/org/starexec/app/Starexec.java
@@ -109,7 +109,13 @@ public class Starexec implements ServletContextListener {
 		if (R.IS_FULL_STAREXEC_INSTANCE) {
 			R.BACKEND.initialize(R.BACKEND_ROOT);
 		}
-		R.PUBLIC_USER_ID = Users.get("public").getId();
+
+		try {
+			R.PUBLIC_USER_ID = Users.get("public").getId();
+		} catch (Exception e) {
+			log.fatal("!!! No public user found !!! Cannot continue !!!", e);
+			throw e;
+		}
 
 		System.setProperty("http.proxyHost", R.HTTP_PROXY_HOST);
 		System.setProperty("http.proxyPort", R.HTTP_PROXY_PORT);


### PR DESCRIPTION
If there is no user with email `public` then `Users.get("public")` returns `Null`.
This causes `.getId()` to throw a NullPointerException and StarExec will shutdown.

This change logs an error message when this happens, so hopefully debugging will be a bit easier next time.