### PR TITLE
Print error messages even when verbose=false

### DIFF
--- a/src/org/starexec/command/CommandParser.java
+++ b/src/org/starexec/command/CommandParser.java
@@ -531,10 +531,8 @@ class CommandParser {
 					System.out.println("Processing Command: " + line);
 				}
 				status = parseCommand(line);
-				if (verbose) {
-					MessagePrinter.printStatusMessage(status, this);
-					MessagePrinter.printWarningMessages();
-				}
+				MessagePrinter.printStatusMessage(status, this);
+				MessagePrinter.printWarningMessages();
 
 				// either of the following two statuses indicate that we should
 				// stop


### PR DESCRIPTION
If a command fails, StarExecCommand should print an error message, even if not in `verbose` mode.