### PR TITLE
Avoid duplicate files in generated WAR

### DIFF
--- a/build/build-compile.xml
+++ b/build/build-compile.xml
@@ -108,7 +108,6 @@
 		<war compress="${compression-enabled}" level="9" warfile="${war-file-name}" webxml="${web-inf}/web.xml">
 			<classes dir="${class-dir}" />
 			<fileset dir="WebContent" excludes="**/*.scss,**/context.template,**/starlogo.png"/>
-			<lib dir="${starcomlib}"/>
 			<zipfileset file="${Web.Image.Banner}" fullpath="images/starlogo.png" />
 			<zipfileset file="${Cluster.MachineSpecs}" fullpath="public/machine-specs.txt" />
 		</war>


### PR DESCRIPTION
Fixes #101 

I'm not sure if it's better to exclude the *.jar files from `WebContent`, or just drop `starcomlib`.

I am leaning towards dropping `starcomlib`, since it is semantically for StarExecCommand rather than the full StarExec. In practice, it makes little difference.