### PR TITLE
Generalize and globalize `list-count` logic

### DIFF
--- a/WebContent/js/admin/cluster.js
+++ b/WebContent/js/admin/cluster.js
@@ -325,10 +325,6 @@ function fnPaginationHandler(sSource, aoData, fnCallback) {
 		aoData,
 		function(nextDataTablePage) {
 			if (parseReturnCode(nextDataTablePage)) {
-				// Update the number displayed in this DataTable's fieldset
-				$('#reservationExpd')
-				.children('span:first-child')
-				.text(nextDataTablePage.iTotalRecords);
 				// Replace the current page with the newly received page
 				fnCallback(nextDataTablePage);
 			}

--- a/WebContent/js/admin/queue.js
+++ b/WebContent/js/admin/queue.js
@@ -162,14 +162,8 @@ function fnPaginationHandler(sSource, aoData, fnCallback) {
 		sSource + "nodes/dates/reservation/" + id + "/pagination",
 		aoData,
 		function(nextDataTablePage) {
-			s = parseReturnCode(nextDataTablePage);
+			var s = parseReturnCode(nextDataTablePage);
 			if (s) {
-
-				// Update the number displayed in this DataTable's fieldset
-				$('#nodeExpd')
-				.children('span:first-child')
-				.text(nextDataTablePage.iTotalRecords);
-
 				// Replace the current page with the newly received page
 				fnCallback(nextDataTablePage);
 			}

--- a/WebContent/js/admin/user.js
+++ b/WebContent/js/admin/user.js
@@ -8,10 +8,6 @@ jQuery(function($) {
 			aoData,
 			function(nextDataTablePage) {
 				if (parseReturnCode(nextDataTablePage)) {
-					// Update the number displayed in this DataTable's fieldset
-					$('#userExpd')
-					.children('span:first-child')
-					.text(nextDataTablePage.iTotalRecords);
 					// Replace the current page with the newly received page
 					fnCallback(nextDataTablePage);
 				}

--- a/WebContent/js/details/recycleBin.js
+++ b/WebContent/js/details/recycleBin.js
@@ -96,16 +96,6 @@ jQuery(function($) {
 		})
 	);
 
-	/**
-	 * Update the count in the label for each table's panel
-	 */
-	$(document).on("draw.dt", function(e, settings) {
-		var info = new $.fn.dataTable.Api(settings).page.info();
-		$(settings.oInstance) // The DataTable being drawn
-			.parents('fieldset').find('.expd>span:first-child') // Find the label
-			.text(info.recordsTotal); // Set the current count
-	});
-
 	$("#rbenchmarks, #rsolvers")
 	.on("mousedown", "tr:not(:has(.dataTables_empty))", function() {
 		$(this).toggleClass("row_selected");

--- a/WebContent/js/details/user.js
+++ b/WebContent/js/details/user.js
@@ -82,16 +82,6 @@ $(document).ready(function() {
 		"fnServerData": fnPaginationHandler
 	});
 
-	/**
-	 * Update the count in the label for each table's panel
-	 */
-	$(document).on("draw.dt", function(e, settings) {
-		var info = new $.fn.dataTable.Api(settings).page.info();
-		$(settings.oInstance) // The DataTable being drawn
-			.parents('fieldset').find('legend>span:first-child') // Find the label
-			.text(info.recordsTotal); // Set the current count
-	});
-
 	jTable = $('#jobs').dataTable(dataTableConfig);
 	solverTable = $('#solvers').dataTable(dataTableConfig);
 	benchTable = $('#benchmarks').dataTable(dataTableConfig);

--- a/WebContent/js/edit/spacePermissions.js
+++ b/WebContent/js/edit/spacePermissions.js
@@ -254,16 +254,6 @@ function initDataTables() {
 		"fnServerData": addUsersPaginationHandler // included in this file
 	}));
 
-	/**
-	 * Update the count in the label for each table's panel
-	 */
-	$('#usersTable,#addUsers').on("draw.dt", function(e, settings) {
-		var info = new $.fn.dataTable.Api(settings).page.info();
-		$(settings.oInstance) // The DataTable being drawn
-			.parents('fieldset').find('legend>span:first-child') // Find the label
-			.text(info.recordsTotal); // Set the current count
-	});
-
 	/* Only one user can be selected at a time */
 	$('#userField .selectWrap').hide();
 

--- a/WebContent/js/explore/cluster.js
+++ b/WebContent/js/explore/cluster.js
@@ -263,7 +263,7 @@ function getDetails(id, type, parent_node) {
 	jobPairTable.fnClearTable();	//immediately get rid of the current data, which makes it look more responsive
 	if (type == 'active_queue' || type == 'inactive_queue') {
 		var $jobs = $("#jobs");
-		$("#clusterExpd").html("Enqueued Job Pairs <span> (+)</span>");
+		$("#clusterExpd").html("<span class='list-count'/> Enqueued Job Pairs <span>(+)</span>");
 		$("#jobsContainer").show();
 		url = starexecRoot + "services/cluster/queues/details/" + id;
 		qid = id;
@@ -279,7 +279,7 @@ function getDetails(id, type, parent_node) {
 		}
 		$("#detailField .expdContainer").css("display", "none");
 	} else if (type == 'enabled_node' || type == 'disabled_node') {
-		$("#clusterExpd").text("Running Job Pairs");
+		$("#clusterExpd").html("<span class='list-count'/> Running Job Pairs");
 		$("#jobsContainer").hide();
 		url = starexecRoot + "services/cluster/nodes/details/" + id;
 		qid = parent_node.attr("id");

--- a/WebContent/js/explore/spaces.js
+++ b/WebContent/js/explore/spaces.js
@@ -1261,16 +1261,6 @@ function initDataTables() {
 		"aaSorting": [] // tells server to sort by 'created'
 	});
 
-	/**
-	 * Update the count in the label for each table's panel
-	 */
-	$(document).on("draw.dt", function(e, settings) {
-		var info = new $.fn.dataTable.Api(settings).page.info();
-		$(settings.oInstance) // The DataTable being drawn
-			.parents('fieldset').find('.expd>span:first-child') // Find the label
-			.text(info.recordsTotal); // Set the current count
-	});
-
 	// Setup the DataTable objects
 	userTable = $('#users').dataTable(dataTableConfig);
 	solverTable = $('#solvers').dataTable(dataTableConfig);

--- a/WebContent/js/master.js
+++ b/WebContent/js/master.js
@@ -177,6 +177,11 @@ jQuery(function($) {
 		} else {
 			selectAll.show();
 		}
+
+		/* Update the `list-count` of the container, if one exists */
+		$(settings.oInstance) // The DataTable being drawn
+			.parents('fieldset').find('.list-count') // Find the label
+			.text(info.recordsTotal); // Set the current count
 	});
 
 	/**

--- a/WebContent/js/shared/sharedFunctions.js
+++ b/WebContent/js/shared/sharedFunctions.js
@@ -59,10 +59,6 @@ function initCommunityRequestsTable(
 			function(nextDataTablePage) {
 				var s = parseReturnCode(nextDataTablePage, false);
 				if (s) {
-					// Update the number displayed in this DataTable's fieldset
-					$('#communityExpd')
-					.children('span:first-child')
-					.text(nextDataTablePage.iTotalRecords);
 					// Replace the current page with the newly received page
 					fnCallback(nextDataTablePage);
 				}

--- a/WebContent/secure/admin/community.jsp
+++ b/WebContent/secure/admin/community.jsp
@@ -48,7 +48,7 @@
 			</ul>
 		</fieldset>
 		<fieldset id="communityField" class="expdContainer">
-			<legend class="expd" id="communityExpd"><span>0</span> pending
+			<legend class="expd" id="communityExpd"><span class="list-count"></span> pending
 				community requests
 			</legend>
 			<table id="commRequests">

--- a/WebContent/secure/admin/job.jsp
+++ b/WebContent/secure/admin/job.jsp
@@ -14,7 +14,7 @@
                js="lib/jquery.heatcolor.0.0.1.min, common/format, admin/job, lib/jquery.dataTables.min"
                css="common/table, explore/common">
 	<fieldset id="jobField" class="expdContainer">
-		<legend class="expd" id="jobExpd">jobs</legend>
+		<legend class="expd" id="jobExpd"><span class="list-count"></span> jobs</legend>
 		<ul class="actionList">
 			<c:if test="${isSystemPaused}">
 				<li>

--- a/WebContent/secure/admin/user.jsp
+++ b/WebContent/secure/admin/user.jsp
@@ -7,7 +7,7 @@
                js="admin/user, lib/jquery-ui.min, lib/jquery.dataTables.min"
                css="admin/user, common/table, explore/common, admin/admin, jqueryui/jquery-ui">
 	<fieldset id="userField" class="expdContainer">
-		<legend class="expd" id="userExpd"><span>0</span> users</legend>
+		<legend class="expd" id="userExpd"><span class="list-count"></span> users</legend>
 		<ul id="actionList">
 			<li><a type="btnRun" id="addUser"
 			       href="${starexecRoot}/secure/admin/addUser.jsp">Create New

--- a/WebContent/secure/details/recycleBin.jsp
+++ b/WebContent/secure/details/recycleBin.jsp
@@ -22,7 +22,7 @@
                js="common/delaySpinner, details/recycleBin, lib/jquery.dataTables.min, lib/jquery.jstree, lib/jquery.qtip.min, lib/jquery.heatcolor.0.0.1.min"
                css="common/delaySpinner, common/table, explore/common, explore/spaces, details/shared, details/recycleBin">
 	<fieldset id="recycledSolverField">
-		<legend class="expd" id="recycledSolverExpd"><span>0</span> recycled
+		<legend class="expd" id="recycledSolverExpd"><span class="list-count"></span> recycled
 			solvers
 		</legend>
 		<ul class="actionList">

--- a/WebContent/secure/details/user.jsp
+++ b/WebContent/secure/details/user.jsp
@@ -189,7 +189,7 @@
 				</table>
 			</fieldset>
 			<fieldset id="solverField" class="expd">
-				<legend class="expd" id="solverExpd"><span>0</span> solvers
+				<legend class="expd" id="solverExpd"><span class="list-count"></span> solvers
 				</legend>
 				<ul class="actionList">
 					<li>
@@ -216,7 +216,7 @@
 				</table>
 			</fieldset>
 			<fieldset id="benchField" class="expd">
-				<legend class="expd" id="benchExpd"><span>0</span> benchmarks
+				<legend class="expd" id="benchExpd"><span class="list-count"></span> benchmarks
 				</legend>
 				<ul class="actionList">
 					<li>
@@ -244,7 +244,7 @@
 				</table>
 			</fieldset>
 			<fieldset id="jobField" class="expd">
-				<legend class="expd" id="jobExpd"><span>0</span> jobs</legend>
+				<legend class="expd" id="jobExpd"><span class="list-count"></span> jobs</legend>
 				<ul class="actionList">
 					<li>
 						<button id="deleteJob"

--- a/WebContent/secure/edit/spacePermissions.jsp
+++ b/WebContent/secure/edit/spacePermissions.jsp
@@ -62,7 +62,7 @@
 		<p id="spaceDesc" class="accent"></p>
 		<p id="spaceID" class="accent"></p>
 		<fieldset id="userField">
-			<legend id="usersLegend" class="userExpd"><span>0</span> users</legend>
+			<legend id="usersLegend" class="userExpd"><span class="list-count"></span> users</legend>
 			<table id="usersTable">
 				<thead>
 				<tr>
@@ -224,7 +224,7 @@
 
 		<h3 class="addUsersTitle">Add users to <span class="spaceName"></span></h3>
 		<fieldset id="addUsersField">
-			<legend id="addUsersLegend" class="userExpd"><span>0</span> users
+			<legend id="addUsersLegend" class="userExpd"><span class="list-count"></span> users
 			</legend>
 			<table id="addUsers">
 				<thead>

--- a/WebContent/secure/explore/cluster.jsp
+++ b/WebContent/secure/explore/cluster.jsp
@@ -17,7 +17,7 @@
 		<p class="accent" id="queueID"></p>
 
 		<fieldset id="jobsContainer" class="expdContainer">
-			<legend class="expd">Running Jobs</legend>
+			<legend class="expd"><span class="list-count"></span> Running Jobs</legend>
 			<table id="jobs"></table>
 		</fieldset>
 

--- a/WebContent/secure/explore/communities.jsp
+++ b/WebContent/secure/explore/communities.jsp
@@ -50,14 +50,14 @@
 		<p id="commDesc" class="accent"></p>
 
 		<!--<fieldset id="websiteField">
-			<legend><span>0</span> website(s)</legend>						
-			<div id="webDiv">				
+			<legend><span class="list-count"></span> website(s)</legend>
+			<div id="webDiv">
 				<ul id="websites" class="horizontal"></ul>
-			</div>		
+			</div>
 		</fieldset>-->
 
 		<fieldset id="leaderField">
-			<legend class="expd"><span>0</span> leaders</legend>
+			<legend class="expd"><span class="list-count"></span> leaders</legend>
 			<table id="leaders">
 				<thead>
 				<tr>
@@ -70,7 +70,7 @@
 		</fieldset>
 
 		<fieldset id="memberField">
-			<legend class="expd"><span>0</span> members</legend>
+			<legend class="expd"><span class="list-count"></span> members</legend>
 			<table id="members">
 				<thead>
 				<tr>
@@ -84,7 +84,7 @@
 
 		<c:if test="${!hideCommunityRequests}">
 			<fieldset id="communityField">
-				<legend class="expd" id="communityExpd"><span>0</span> pending
+				<legend class="expd" id="communityExpd"><span class="list-count"></span> pending
 					community requests
 				</legend>
 				<table id="commRequests">

--- a/WebContent/secure/explore/spaces.jsp
+++ b/WebContent/secure/explore/spaces.jsp
@@ -53,7 +53,7 @@
 		<p id="spaceDesc" class="accent"></p>
 		<p id="spaceID" class="accent"></p>
 		<fieldset id="jobField">
-			<legend class="expd" id="jobExpd"><span>0</span> jobs</legend>
+			<legend class="expd" id="jobExpd"><span class="list-count"></span> jobs</legend>
 			<ul class="actionList">
 				<li><a class="btnRun" id="addJob"
 				       href="${starexecRoot}/secure/add/job.jsp">create job</a>
@@ -93,7 +93,7 @@
 		</fieldset>
 
 		<fieldset id="solverField">
-			<legend class="expd" id="solverExpd"><span>0</span> solvers</legend>
+			<legend class="expd" id="solverExpd"><span class="list-count"></span> solvers</legend>
 			<ul class="actionList">
 				<li><a class="btnUp" id="uploadSolver"
 				       href="${starexecRoot}/secure/add/solver.jsp">upload
@@ -118,7 +118,7 @@
 		</fieldset>
 
 		<fieldset id="benchField">
-			<legend class="expd" id="benchExpd"><span>0</span> benchmarks
+			<legend class="expd" id="benchExpd"><span class="list-count"></span> benchmarks
 			</legend>
 			<ul class="actionList">
 				<li>
@@ -152,7 +152,7 @@
 		</fieldset>
 
 		<fieldset id="userField">
-			<legend class="expd" id="userExpd"><span>0</span> users</legend>
+			<legend class="expd" id="userExpd"><span class="list-count"></span> users</legend>
 			<table id="users">
 				<thead>
 				<tr>
@@ -172,7 +172,7 @@
 		</fieldset>
 
 		<fieldset id="spaceField">
-			<legend class="expd" id="spaceExpd"><span>0</span> subspaces
+			<legend class="expd" id="spaceExpd"><span class="list-count"></span> subspaces
 			</legend>
 			<ul class="actionList">
 				<li><a class="btnAdd" id="addSpace"


### PR DESCRIPTION
Many (most?) of our lists include a count of all list items in the label for the fieldset. This commit refactors all of that logic into a single hook in `master.js`