### PR TITLE
Properly send JSP error pages

### DIFF
--- a/WebContent/public/jobs/job.jsp
+++ b/WebContent/public/jobs/job.jsp
@@ -28,15 +28,18 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"Job does not exist or is restricted"
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given job id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/public/messages/email_changed.jsp
+++ b/WebContent/public/messages/email_changed.jsp
@@ -7,6 +7,7 @@
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="email changed">

--- a/WebContent/secure/add/batchJob.jsp
+++ b/WebContent/secure/add/batchJob.jsp
@@ -18,17 +18,20 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You do not have permission to create jobs here"
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The parent space id was not in the correct format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_NOT_FOUND,
 				"You do not have permission to upload jobs to this space or the space does not exist"
 		);
+		return;
 	}
 %>
 <star:template title="upload XML configuration for a job in ${space.name}"

--- a/WebContent/secure/add/batchSpace.jsp
+++ b/WebContent/secure/add/batchSpace.jsp
@@ -18,17 +18,20 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You do not have permission to add spaces here"
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The parent space id was not in the correct format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_NOT_FOUND,
 				"You do not have permission to upload spaces to this space or the space does not exist"
 		);
+		return;
 	}
 %>
 <star:template

--- a/WebContent/secure/add/benchmarks.jsp
+++ b/WebContent/secure/add/benchmarks.jsp
@@ -34,18 +34,21 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You do not have permission to add benchmarks here"
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The parent space id was not in the correct format"
 		);
+		return;
 	} catch (Exception e) {
 		e.printStackTrace();
 		response.sendError(
 				HttpServletResponse.SC_NOT_FOUND,
 				"You do not have permission to upload benchmarks to this space or the space does not exist"
 		);
+		return;
 	}
 %>
 

--- a/WebContent/secure/add/configuration.jsp
+++ b/WebContent/secure/add/configuration.jsp
@@ -19,17 +19,20 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You do not have permission to add configurations here."
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The parent solver id was not in the correct format."
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_NOT_FOUND,
 				"You do not have permission to upload configurations to this solver or the solver does not exist"
 		);
+		return;
 	}
 %>
 <star:template title="add to ${solver.name}" css="add/configuration"

--- a/WebContent/secure/add/job.jsp
+++ b/WebContent/secure/add/job.jsp
@@ -17,6 +17,7 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You do not have permission to create a job here"
 			);
+			return;
 		} else {
 			User u = Users.get(userId);
 			int pairsUsed = Jobs.countPairsByUser(userId);
@@ -56,11 +57,13 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The space id was not in the correct format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_NOT_FOUND,
 				"You do not have permission to add to this space or the space does not exist"
 		);
+		return;
 	}
 	request.setAttribute(
 			"MINIMUM_RESULTS_INTERVAL", R.MINIMUM_RESULTS_INTERVAL);

--- a/WebContent/secure/add/jobPairs.jsp
+++ b/WebContent/secure/add/jobPairs.jsp
@@ -45,6 +45,7 @@
 		response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
 		                   Util.getStackTrace(e)
 		);
+		return;
 	}
 %>
 <star:template title="Add Job Pairs"

--- a/WebContent/secure/add/picture.jsp
+++ b/WebContent/secure/add/picture.jsp
@@ -19,9 +19,11 @@
 					HttpServletResponse.SC_BAD_REQUEST,
 					"The image parameters were invalid"
 			);
+			return;
 		}
 	} catch (Exception e) {
 		response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/add/quickJob.jsp
+++ b/WebContent/secure/add/quickJob.jsp
@@ -24,6 +24,7 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You do not have permission to create a job here"
 			);
+			return;
 		} else {
 			if (spaceId > 0) {
 				request.setAttribute("spaceName", Spaces.getName(spaceId));
@@ -66,12 +67,14 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The space id was not in the correct format"
 		);
+		return;
 	} catch (Exception e) {
 		log.debug(e.getMessage(), e);
 		response.sendError(
 				HttpServletResponse.SC_NOT_FOUND,
 				"You do not have permission to add to this space or the space does not exist"
 		);
+		return;
 	}
 %>
 <jsp:useBean id="now" class="java.util.Date"/>

--- a/WebContent/secure/add/solver.jsp
+++ b/WebContent/secure/add/solver.jsp
@@ -19,6 +19,7 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You do not have permission to add solvers here"
 			);
+			return;
 		}
 		List<DefaultSettings> listOfDefaultSettings =
 				Settings.getDefaultSettingsVisibleByUser(userId);
@@ -34,11 +35,13 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The parent space id was not in the correct format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_NOT_FOUND,
 				"You do not have permission to upload solvers to this space or the space does not exist"
 		);
+		return;
 	}
 %>
 <star:template title="upload solver to ${space.name}"

--- a/WebContent/secure/add/space.jsp
+++ b/WebContent/secure/add/space.jsp
@@ -20,18 +20,21 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You do not have permission to add a space here"
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The parent space id was not in the correct format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_NOT_FOUND,
 				"You do not have permission to add to this space or the space does not exist" +
 						e.getMessage()
 		);
+		return;
 	}
 %>
 

--- a/WebContent/secure/add/to_community.jsp
+++ b/WebContent/secure/add/to_community.jsp
@@ -7,7 +7,7 @@
 	try {
 		int comId = Integer.parseInt((String) request.getParameter("cid"));
 		Space com = Communities.getDetails(comId);
-	
+
 	/*
 	*  If the user is attempting to join a community they are apart of, redirect them
 	*  back to the community explorer
@@ -19,11 +19,13 @@
 
 		if (com == null) {
 			response.sendError(HttpServletResponse.SC_NOT_FOUND);
+			return;
 		} else {
 			request.setAttribute("com", com);
 		}
 	} catch (Exception e) {
 		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		return;
 	}
 %>
 

--- a/WebContent/secure/admin/assocCommunity.jsp
+++ b/WebContent/secure/admin/assocCommunity.jsp
@@ -16,9 +16,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given user id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="give communities acces to queues"

--- a/WebContent/secure/admin/job.jsp
+++ b/WebContent/secure/admin/job.jsp
@@ -8,6 +8,7 @@
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="Jobs Admin"

--- a/WebContent/secure/admin/moveNodes.jsp
+++ b/WebContent/secure/admin/moveNodes.jsp
@@ -16,9 +16,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given user id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="move nodes to queue"

--- a/WebContent/secure/admin/permissions.jsp
+++ b/WebContent/secure/admin/permissions.jsp
@@ -14,9 +14,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given user id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/admin/queue.jsp
+++ b/WebContent/secure/admin/queue.jsp
@@ -15,9 +15,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given user id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="create queue"

--- a/WebContent/secure/admin/starexec.jsp
+++ b/WebContent/secure/admin/starexec.jsp
@@ -9,9 +9,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given user id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="Admin"

--- a/WebContent/secure/admin/testResults.jsp
+++ b/WebContent/secure/admin/testResults.jsp
@@ -11,6 +11,7 @@
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="${sequenceName}"

--- a/WebContent/secure/details/XMLuploadStatus.jsp
+++ b/WebContent/secure/details/XMLuploadStatus.jsp
@@ -25,11 +25,13 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"XML Upload Status does not exist or is restricted"
 			);
+			return;
 		}
 	} catch (Exception e) {
 		response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
 		                   e.getMessage()
 		);
+		return;
 	}
 %>
 

--- a/WebContent/secure/details/anonymousJobPageKey.jsp
+++ b/WebContent/secure/details/anonymousJobPageKey.jsp
@@ -8,6 +8,7 @@
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="${job.name}"

--- a/WebContent/secure/details/benchmark.jsp
+++ b/WebContent/secure/details/benchmark.jsp
@@ -22,9 +22,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given benchmark id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="${benchPageTitle}" js="${js}"

--- a/WebContent/secure/details/configuration.jsp
+++ b/WebContent/secure/details/configuration.jsp
@@ -21,6 +21,7 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"the configuration does not exist or is restricted"
 			);
+			return;
 		}
 
 		// The solver is valid...
@@ -30,6 +31,7 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"the solver does not exist or is restricted"
 			);
+			return;
 		}
 
 		// Build the configuration file path
@@ -43,6 +45,7 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"the configuration file path points to a location that does not exist on disk"
 			);
+			return;
 		}
 
 		con.setDescription(GeneralSecurity.getHTMLSafeString(
@@ -58,6 +61,7 @@
 		log.error("Exception", e);
 		e.printStackTrace();
 		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		return;
 	}
 %>
 <star:template title="${config.name}"

--- a/WebContent/secure/details/conflictingBenchmarks.jsp
+++ b/WebContent/secure/details/conflictingBenchmarks.jsp
@@ -43,6 +43,7 @@
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template

--- a/WebContent/secure/details/conflictingSolvers.jsp
+++ b/WebContent/secure/details/conflictingSolvers.jsp
@@ -13,14 +13,13 @@
 						HttpServletResponse.SC_NOT_FOUND,
 						"This job has been deleted. You likely want to remove it from your spaces"
 				);
-				return;
 			} else {
 				response.sendError(
 						HttpServletResponse.SC_NOT_FOUND,
 						"Job does not exist or is restricted"
 				);
-				return;
 			}
+			return;
 		}
 		int benchId = Integer.parseInt(request.getParameter("benchId"));
 		request.setAttribute("benchmark", Benchmarks.get(benchId));
@@ -32,6 +31,7 @@
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="conflicting solvers for benchmark ${benchmark.name}"

--- a/WebContent/secure/details/job.jsp
+++ b/WebContent/secure/details/job.jsp
@@ -14,9 +14,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given job id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="${pageTitle}"

--- a/WebContent/secure/details/jobAttributes.jsp
+++ b/WebContent/secure/details/jobAttributes.jsp
@@ -51,15 +51,18 @@
 						"Job does not exist or is restricted"
 				);
 			}
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given job id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/details/jobMatrixView.jsp
+++ b/WebContent/secure/details/jobMatrixView.jsp
@@ -34,9 +34,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given job id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 
 %>

--- a/WebContent/secure/details/jobPanelView.jsp
+++ b/WebContent/secure/details/jobPanelView.jsp
@@ -21,20 +21,24 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"This job has been deleted. You likely want to remove it from your spaces"
 			);
+			return;
 		} else {
 			response.sendError(
 					HttpServletResponse.SC_NOT_FOUND,
 					"Job does not exist or is restricted"
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given job id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="${job.name}"

--- a/WebContent/secure/details/pair.jsp
+++ b/WebContent/secure/details/pair.jsp
@@ -13,6 +13,7 @@
 		if (jp == null) {
 			response.sendError(
 					HttpServletResponse.SC_NOT_FOUND, "Job does not exist");
+			return;
 		} else if (Permissions.canUserSeeJob(jp.getJobId(), userId)
 		                      .isSuccess()) {
 			Job j = Jobs.get(jp.getJobId());
@@ -54,6 +55,7 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You do not have permission to view this job pair"
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		log.error(nfe.getMessage(), nfe);
@@ -61,10 +63,12 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given pair id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		log.error(e.getMessage(), e);
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="${job.name} pair #${pair.id}"

--- a/WebContent/secure/details/pairsInSpace.jsp
+++ b/WebContent/secure/details/pairsInSpace.jsp
@@ -27,8 +27,6 @@
 		}
 
 		Job j = Jobs.get(space.getJobId());
-
-
 		if (j != null && JobSecurity.isValidGetPairType(type)) {
 			JobSpace s = Spaces.getJobSpace(jobSpaceId);
 			request.setAttribute("jobspace", s);
@@ -41,11 +39,13 @@
 						HttpServletResponse.SC_NOT_FOUND,
 						"This job has been deleted. You likely want to remove it from your spaces"
 				);
+				return;
 			} else {
 				response.sendError(
 						HttpServletResponse.SC_NOT_FOUND,
 						"Job does not exist or is restricted"
 				);
+				return;
 			}
 		}
 	} catch (NumberFormatException nfe) {
@@ -53,9 +53,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given job id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/details/recycleBin.jsp
+++ b/WebContent/secure/details/recycleBin.jsp
@@ -12,9 +12,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given user id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/details/solver.jsp
+++ b/WebContent/secure/details/solver.jsp
@@ -21,9 +21,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given solver id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/details/solverComparison.jsp
+++ b/WebContent/secure/details/solverComparison.jsp
@@ -42,11 +42,13 @@
 						HttpServletResponse.SC_NOT_FOUND,
 						"This job has been deleted. You likely want to remove it from your spaces"
 				);
+				return;
 			} else {
 				response.sendError(
 						HttpServletResponse.SC_NOT_FOUND,
 						"Job does not exist or is restricted"
 				);
+				return;
 			}
 		}
 	} catch (NumberFormatException nfe) {
@@ -54,9 +56,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given job id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/details/solverconfigs.jsp
+++ b/WebContent/secure/details/solverconfigs.jsp
@@ -4,7 +4,7 @@
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
-<%-- handles requests to print out solver configurations 
+<%-- handles requests to print out solver configurations
 currently only used in StarexecCommand --%>
 <%
 	try {
@@ -13,6 +13,7 @@ currently only used in StarexecCommand --%>
 		if (!Permissions.canUserSeeSolver(solverid, userId)) {
 			response.sendError(
 					HttpServletResponse.SC_FORBIDDEN, "Invalid Permissions");
+			return;
 		} else {
 			int limit = Integer.parseInt(request.getParameter("limit"));
 
@@ -44,11 +45,12 @@ currently only used in StarexecCommand --%>
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given solver id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
 				"Life, Jim, but not as we know it"
 		);
+		return;
 	}
 %>
-

--- a/WebContent/secure/details/uploadStatus.jsp
+++ b/WebContent/secure/details/uploadStatus.jsp
@@ -27,6 +27,7 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"Upload Status does not exist or is restricted"
 			);
+			return;
 		}
 		if (bS != null) {
 			request.setAttribute("badBenches", bS);
@@ -35,16 +36,19 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"Upload Status does not exist or is restricted"
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given upload status id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
 		                   e.getMessage()
 		);
+		return;
 	}
 %>
 

--- a/WebContent/secure/details/user.jsp
+++ b/WebContent/secure/details/user.jsp
@@ -50,6 +50,7 @@
 							HttpServletResponse.SC_NOT_FOUND,
 							"Job does not exist or is restricted"
 					);
+					return;
 				}
 			}
 			boolean canSubscribeToErrorLogs =
@@ -62,15 +63,18 @@
 		} else {
 			response.sendError(
 					HttpServletResponse.SC_NOT_FOUND, "User does not exist");
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given user id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/edit/account.jsp
+++ b/WebContent/secure/edit/account.jsp
@@ -35,6 +35,7 @@
 						HttpServletResponse.SC_NOT_FOUND,
 						"Must be the administrator to access this page"
 				);
+				return;
 			} else {
 				List<DefaultSettings> listOfDefaultSettings =
 						Settings.getDefaultSettingsVisibleByUser(userId);
@@ -87,6 +88,7 @@
 		}
 	} catch (Exception e) {
 		response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+		return;
 	}
 %>
 <star:template title="edit account"

--- a/WebContent/secure/edit/benchmark.jsp
+++ b/WebContent/secure/edit/benchmark.jsp
@@ -23,6 +23,7 @@
 						HttpServletResponse.SC_FORBIDDEN,
 						"Only the owner of this benchmark can edit details about it."
 				);
+				return;
 			} else {
 				request.setAttribute("bench", b);
 				if (b.isDownloadable()) {
@@ -42,11 +43,13 @@
 						HttpServletResponse.SC_NOT_FOUND,
 						"This benchmark has been deleted. You likely want to remove it from your spaces"
 				);
+				return;
 			} else {
 				response.sendError(
 						HttpServletResponse.SC_NOT_FOUND,
 						"Benchmark does not exist or is restricted"
 				);
+				return;
 			}
 		}
 	} catch (NumberFormatException nfe) {
@@ -54,9 +57,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given benchmark id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/edit/community.jsp
+++ b/WebContent/secure/edit/community.jsp
@@ -26,11 +26,13 @@
 
 		if (com == null) {
 			response.sendError(HttpServletResponse.SC_NOT_FOUND);
+			return;
 		} else if ((perm == null || !perm.isLeader()) && !admin) {
 			response.sendError(
 					HttpServletResponse.SC_FORBIDDEN,
 					"Only community leaders can edit their communities"
 			);
+			return;
 		} else {
 			DefaultSettings settings = Communities.getDefaultSettings(id);
 			request.setAttribute("setting", settings);
@@ -85,6 +87,7 @@
 		}
 	} catch (Exception e) {
 		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		return;
 	}
 %>
 

--- a/WebContent/secure/edit/configuration.jsp
+++ b/WebContent/secure/edit/configuration.jsp
@@ -41,15 +41,18 @@
 						HttpServletResponse.SC_NOT_FOUND,
 						"the configuration file path points to a location that does not exist on disk"
 				);
+				return;
 			}
 		} else {
 			response.sendError(
 					HttpServletResponse.SC_NOT_FOUND,
 					"the configuration does not exist or is restricted"
 			);
+			return;
 		}
 	} catch (Exception e) {
 		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		return;
 	}
 %>
 

--- a/WebContent/secure/edit/defaultPrimitive.jsp
+++ b/WebContent/secure/edit/defaultPrimitive.jsp
@@ -34,9 +34,11 @@
 					HttpServletResponse.SC_NOT_ACCEPTABLE,
 					"The given type parameter was not correct-- it must be either solver or benchmark"
 			);
+			return;
 		}
 	} catch (Exception e) {
 		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		return;
 	}
 %>
 

--- a/WebContent/secure/edit/processBenchmarks.jsp
+++ b/WebContent/secure/edit/processBenchmarks.jsp
@@ -23,9 +23,11 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You must be a member of the space in which you want to process benchmarks"
 			);
+			return;
 		}
 	} catch (Exception e) {
 		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		return;
 	}
 %>
 

--- a/WebContent/secure/edit/processor.jsp
+++ b/WebContent/secure/edit/processor.jsp
@@ -35,6 +35,7 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"the processor does not exist or is restricted"
 			);
+			return;
 		} else {
 			request.setAttribute("proc", proc);
 
@@ -57,6 +58,7 @@
 		}
 	} catch (Exception e) {
 		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		return;
 	}
 %>
 <star:template title="edit ${proc.name}"

--- a/WebContent/secure/edit/queue.jsp
+++ b/WebContent/secure/edit/queue.jsp
@@ -20,15 +20,18 @@
 					HttpServletResponse.SC_FORBIDDEN,
 					"You do not have permission to view this page."
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given queue id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/edit/resubmitPairs.jsp
+++ b/WebContent/secure/edit/resubmitPairs.jsp
@@ -26,18 +26,22 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"This job has been deleted. You likely want to remove it from your spaces"
 			);
+			return;
 		} else {
 			response.sendError(
 					HttpServletResponse.SC_NOT_FOUND, status.getMessage());
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given job id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="rerun pairs for ${job.name}"

--- a/WebContent/secure/edit/solver.jsp
+++ b/WebContent/secure/edit/solver.jsp
@@ -34,6 +34,7 @@
 						HttpServletResponse.SC_FORBIDDEN,
 						"Only the owner of this solver can edit details about it."
 				);
+				return;
 			}
 		} else {
 			if (Solvers.isSolverDeleted(solverId)) {
@@ -41,11 +42,13 @@
 						HttpServletResponse.SC_NOT_FOUND,
 						"This solver has been deleted. You likely want to remove it from your spaces."
 				);
+				return;
 			} else {
 				response.sendError(
 						HttpServletResponse.SC_NOT_FOUND,
 						"Solver does not exist or is restricted"
 				);
+				return;
 			}
 		}
 	} catch (NumberFormatException nfe) {
@@ -53,9 +56,11 @@
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given solver id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 

--- a/WebContent/secure/edit/space.jsp
+++ b/WebContent/secure/edit/space.jsp
@@ -21,6 +21,7 @@
 						HttpServletResponse.SC_FORBIDDEN,
 						"Only the leaders of this space can edit details about it."
 				);
+				return;
 			} else {
 				request.setAttribute("space", s);
 				Permission dflt = Permissions.getSpaceDefault(s.getId());
@@ -75,15 +76,18 @@
 					HttpServletResponse.SC_NOT_FOUND,
 					"Space does not exist or is restricted"
 			);
+			return;
 		}
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
 				"The given space id was in an invalid format"
 		);
+		return;
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="edit ${space.name}"

--- a/WebContent/secure/edit/spacePermissions.jsp
+++ b/WebContent/secure/edit/spacePermissions.jsp
@@ -42,6 +42,7 @@
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="edit permissions"

--- a/WebContent/secure/explore/reports.jsp
+++ b/WebContent/secure/explore/reports.jsp
@@ -72,6 +72,7 @@
 	} catch (Exception e) {
 		response.sendError(
 				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		return;
 	}
 %>
 <star:template title="Reports ${titleSuffix}" js="explore/reports"


### PR DESCRIPTION
Apparently, if we `response.sendError` without `return`, JSP continues to execute and gets itself into a bad state where eventually error `500` is sent instead of the desired error message.