### PR TITLE
`dbEscape` should escape whole string passed

### DIFF
--- a/src/org/starexec/config/sge/functions.bash
+++ b/src/org/starexec/config/sge/functions.bash
@@ -440,9 +440,9 @@ function dbExec {
 	done
 }
 
-# Will strip quotes from the first argument
+# Will strip quotes from arguments passed
 function dbEscape {
-	echo ${1//[\'\"]/}
+	echo ${@//[\'\"]/}
 }
 
 function sendStageStatus {


### PR DESCRIPTION
Currently, if an unquoted string containing a space is passed to
`dbEscape`, it will truncate the string at the first space.

With this change, `dbEscape` will return the _whole_ string that was
passed, even if it was unquoted.

Fixes #123