### PR TITLE
Do not fail pair if Benchexec is used

### DIFF
--- a/src/org/starexec/config/sge/jobscript
+++ b/src/org/starexec/config/sge/jobscript
@@ -397,7 +397,7 @@ for (( STAGE_INDEX = 0; STAGE_INDEX < NUM_STAGES; ++STAGE_INDEX )); do
 		exit 0
 	fi
 
-	if [ ! -s "$WATCHFILE" ]; then
+	if [[ "$BENCHMARKING_FRAMEWORK" == "$RUNSOLVER" ]] && [[ ! -s "$WATCHFILE" ]]; then
 		log "Runsolver watchfile could not be found. Terminating job pair."
 		copyOutput "$CURRENT_STAGE_NUMBER" "$STDOUT_SAVE_OPTION" "$EXTRA_SAVE_OPTION" "$BENCHMARKING_FRAMEWORK"
 		markRunscriptError "${STAGE_NUMBERS[STAGE_INDEX]}"


### PR DESCRIPTION
If Benchexec is used, no `$WATCHFILE` is created.