### PR TITLE
Bad `id` is not an "error"

### DIFF
--- a/WebContent/secure/details/configuration.jsp
+++ b/WebContent/secure/details/configuration.jsp
@@ -57,6 +57,11 @@
 		request.setAttribute("solver", solver);
 		request.setAttribute("contents", contents);
 		request.setAttribute("isBinary", Util.isBinaryFile(configFile));
+	} catch (NumberFormatException e) {
+		// id is not a number. Possibly a bot looking for SQL injection
+		log.debug("Cannot parse id");
+		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		return;
 	} catch (Exception e) {
 		log.error("Exception", e);
 		e.printStackTrace();


### PR DESCRIPTION
Sometimes our logs get filled up with error messages from bots passing malformed `id` to this page, presumably looking for SQL injection vectors.

It doesn't really impact us, and it is certainly not an `error`, so there's no need to shout to loudly about this.