### PR TITLE
Fix schema version information

### DIFF
--- a/sql/SchemaChanges/00000001.sql
+++ b/sql/SchemaChanges/00000001.sql
@@ -1,0 +1,16 @@
+-- Example Schema Change
+-- If major and minor version are not set, set them both to 1
+
+-- This exists due to an error, where these fields were added to the DB but not
+-- set, introduced in commit cf33c94d3ca0122897ca9c22bcf2a10804d908f2
+
+DROP PROCEDURE IF EXISTS UpdateTo1_1 //
+CREATE PROCEDURE UpdateTo1_1()
+BEGIN
+	IF EXISTS (SELECT 1 FROM system_flags WHERE major_version IS NULL AND minor_version IS NULL) THEN
+		UPDATE system_flags SET major_version=1, minor_version=1;
+	END IF;
+END //
+
+CALL UpdateTo1_1() //
+DROP PROCEDURE IF EXISTS UpdateTo1_1 //

--- a/sql/new-install/MinimalData.sql
+++ b/sql/new-install/MinimalData.sql
@@ -32,5 +32,5 @@ INSERT INTO user_assoc VALUES
 INSERT INTO queues(name, status, global_access) VALUES
 	("all.q", "ACTIVE", true);
 
-INSERT INTO system_flags (paused, test_queue) VALUES
-	(false, 1);
+INSERT INTO system_flags (paused, test_queue, major_version, minor_version) VALUES
+	(false, 1, 1, 1);

--- a/sql/new-install/StarSchema.sql
+++ b/sql/new-install/StarSchema.sql
@@ -726,6 +726,9 @@ CREATE TABLE job_stats (
 );
 
 -- Table that contains some global flags
+--  * Minor version is incremented on each change
+--  * Major version is only incremented when a change may require manual
+--      intervention and cannot be applied automatically
 -- Author: Wyatt Kaiser
 CREATE TABLE system_flags (
 	integrity_keeper ENUM('') NOT NULL,
@@ -736,11 +739,6 @@ CREATE TABLE system_flags (
 	PRIMARY KEY (integrity_keeper),
 	CONSTRAINT system_flags_test_queue FOREIGN KEY (test_queue) REFERENCES queues(id) ON DELETE SET NULL
 );
-
--- Minor version is incremented on each change
--- Major version is only incremented when a change may require manual
---     intervention and cannot be applied automatically
-UPDATE system_flags SET major_version=1, minor_version=1;
 
 -- table for storing statistics for the weekly report
 CREATE TABLE report_data (


### PR DESCRIPTION
Previously, I was trying to add this to the database before the table contained a single row. This meant that the update silently failed. This means that on StarDev and in Miami, these fields are probably `NULL` instead of `1`. This update fixes the problem, making it quite an appropriate first versioned schema update.