### PR TITLE
Do not hardcode preprocessor time limit

### DIFF
--- a/src/org/starexec/jobs/JobManager.java
+++ b/src/org/starexec/jobs/JobManager.java
@@ -712,7 +712,6 @@ public abstract class JobManager {
 				postProcessorPaths.add(p.getFilePath());
 			}
 			p = attrs.getPreProcessor();
-			preProcessorTimeLimits.add("1");
 			if (p == null) {
 				preProcessorTimeLimits.add("");
 				preProcessorPaths.add("");


### PR DESCRIPTION
This line must have been added for debugging, and never should have been committed to production.

6efa794af19a38903195b9fd27195c1c1c64089d