### PR TITLE
Trap Jobscript exit

### DIFF
--- a/src/org/starexec/config/sge/functions.bash
+++ b/src/org/starexec/config/sge/functions.bash
@@ -1113,3 +1113,7 @@ function isOutputValid {
 		return 1
 	fi
 }
+
+function exitJobscript {
+	echo "Jobscript ending."
+}

--- a/src/org/starexec/config/sge/jobscript
+++ b/src/org/starexec/config/sge/jobscript
@@ -129,6 +129,7 @@ NUM_STAGES=${#STAGE_NUMBERS[@]}
 
 trap "limitExceeded 'file write' $EXCEED_FILE_WRITE" SIGXFSZ
 trap 'echo "Jobscript received USR2."' USR2
+trap exitJobscript EXIT
 
 
 #==========================================================================
@@ -496,5 +497,3 @@ done
 setEndTime
 
 cleanWorkspace 0 $SANDBOX_PARAM
-
-echo "Jobscript ending."


### PR DESCRIPTION
There is some cleanup that should _always_ be done at the end of running a JobPair.

This minor change adds a function that will _always_ run after execution of a JobPair has finished, even if the pair terminates early. This will allow refactoring in the future to make sure that (ie:) workspace cleanup always happens.