### PR TITLE
Keep track of when our internal count differs from the actual count

### DIFF
--- a/src/org/starexec/data/database/Common.java
+++ b/src/org/starexec/data/database/Common.java
@@ -93,14 +93,6 @@ public class Common {
 	 * Logs the total number of connections idle and active at the time this is called
 	 */
 	public static void logConnectionsOpen() {
-		if (connectionsOpened-dataPool.getActive() != connectionsDrift) {
-			log.info("logConnectionsOpen",
-			         "Number of active connections reported by dataPool differs from internal count."+
-			         "\n\tconnectionsOpened: "+connectionsOpened+
-			         "\n\tdataPool.getActive(): "+dataPool.getActive()
-			);
-			connectionsDrift = connectionsOpened-dataPool.getActive();
-		}
 		log.info("logConnectionsOpen",
 				"idle=" + dataPool.getIdle()
 				+ "\tactive=" + dataPool.getActive()
@@ -128,6 +120,14 @@ public class Common {
 		try {
 			Connection c = dataPool.getConnection();
 			++connectionsOpened;
+			if (connectionsOpened-dataPool.getActive() != connectionsDrift) {
+				log.info("logConnectionsOpen",
+				         "Number of active connections reported by dataPool differs from internal count." +
+				         "\n\tconnectionsOpened:    " + connectionsOpened +
+				         "\n\tdataPool.getActive(): " + dataPool.getActive()
+				);
+				connectionsDrift = connectionsOpened-dataPool.getActive();
+			}
 			return c;
 		} catch (SQLException e) {
 			log.error("getConnection", "connectionsOpened: "+connectionsOpened, e);

--- a/src/org/starexec/data/database/Common.java
+++ b/src/org/starexec/data/database/Common.java
@@ -25,6 +25,7 @@ public class Common {
 	private static DataSource dataPool = null;
 
 	private static int connectionsOpened = 0;
+	private static int connectionsDrift  = 0;
 
 	//args to append to the mysql URL.
 	private static final String MYSQL_URL_ARGUMENTS = "?autoReconnect=true&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true";
@@ -92,6 +93,14 @@ public class Common {
 	 * Logs the total number of connections idle and active at the time this is called
 	 */
 	public static void logConnectionsOpen() {
+		if (connectionsOpened-dataPool.getActive() != connectionsDrift) {
+			log.info("logConnectionsOpen",
+			         "Number of active connections reported by dataPool differs from internal count."+
+			         "\n\tconnectionsOpened: "+connectionsOpened+
+			         "\n\tdataPool.getActive(): "+dataPool.getActive()
+			);
+			connectionsDrift = connectionsOpened-dataPool.getActive();
+		}
 		log.info("logConnectionsOpen",
 				"idle=" + dataPool.getIdle()
 				+ "\tactive=" + dataPool.getActive()

--- a/src/org/starexec/data/database/Common.java
+++ b/src/org/starexec/data/database/Common.java
@@ -120,18 +120,22 @@ public class Common {
 		try {
 			Connection c = dataPool.getConnection();
 			++connectionsOpened;
-			if (connectionsOpened-dataPool.getActive() != connectionsDrift) {
-				log.info("logConnectionsOpen",
-				         "Number of active connections reported by dataPool differs from internal count." +
-				         "\n\tconnectionsOpened:    " + connectionsOpened +
-				         "\n\tdataPool.getActive(): " + dataPool.getActive()
-				);
-				connectionsDrift = connectionsOpened-dataPool.getActive();
-			}
+			checkConnectionsCount();
 			return c;
 		} catch (SQLException e) {
 			log.error("getConnection", "connectionsOpened: "+connectionsOpened, e);
 			throw e;
+		}
+	}
+
+	private synchronized static void checkConnectionsCount() {
+		if (connectionsOpened-dataPool.getActive() != connectionsDrift) {
+			log.info("logConnectionsOpen",
+			         "Number of active connections reported by dataPool differs from internal count." +
+			         "\n\tconnectionsOpened:    " + connectionsOpened +
+			         "\n\tdataPool.getActive(): " + dataPool.getActive()
+			);
+			connectionsDrift = connectionsOpened-dataPool.getActive();
 		}
 	}
 
@@ -453,5 +457,6 @@ public class Common {
 			// Do nothing
 			log.error("safeClose", e);
 		}
+		checkConnectionsCount();
 	}
 }


### PR DESCRIPTION
I wonder if this is just an issue with multiple threads trying to simultaneously update `connectionsOpened`? Perhaps it should be an `AtomicInteger`?