### PR TITLE
Use scheduleWithFixedDelay for periodic tasks

### DIFF
--- a/src/org/starexec/app/Starexec.java
+++ b/src/org/starexec/app/Starexec.java
@@ -147,7 +147,7 @@ public class Starexec implements ServletContextListener {
 		Set<PeriodicTasks.PeriodicTask> periodicTasks = EnumSet.allOf(PeriodicTasks.PeriodicTask.class);
 		for (PeriodicTasks.PeriodicTask task : periodicTasks) {
 			if (R.IS_FULL_STAREXEC_INSTANCE || !task.fullInstanceOnly) {
-				taskScheduler.scheduleAtFixedRate(task.task, task.delay, task.period.get(), task.unit);
+				taskScheduler.scheduleWithFixedDelay(task.task, task.delay, task.period.get(), task.unit);
 			}
 		}
 


### PR DESCRIPTION
If a task takes longer than `task.delay` we do not need multiple instances of that task to be queued up.

With this change, instead of enqueuing a task every five minutes, the scheduler will run a task, wait for it to finish, and then enqueue the next instance of the task to run after a five minute delay.