### PR TITLE
Disable uploads

### DIFF
--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -850,6 +850,10 @@
     <error-code>500</error-code>
     <location>/public/messages/error.jsp</location>
   </error-page>
+  <error-page>
+    <error-code>503</error-code>
+    <location>/public/messages/error.jsp</location>
+  </error-page>
 
   <!-- Servlet Definitions -->
   <servlet>

--- a/WebContent/js/admin/starexec.js
+++ b/WebContent/js/admin/starexec.js
@@ -101,9 +101,7 @@ function initUI() {
 	$("#clearLoadData").click(function() {
 		$.post(
 			starexecRoot + "services/jobs/clearloadbalance/",
-			function(returnCode) {
-				parseReturnCode(returnCode);
-			},
+			parseReturnCode,
 			"json"
 		);
 	});
@@ -111,9 +109,7 @@ function initUI() {
 	$("#clearSolverCacheData").click(function() {
 		$.post(
 			starexecRoot + "services/jobs/clearsolvercache/",
-			function(returnCode) {
-				parseReturnCode(returnCode);
-			},
+			parseReturnCode,
 			"json"
 		);
 	});
@@ -126,6 +122,25 @@ function initUI() {
 
 					debugModeActive = !debugModeActive;
 					setDebugText();
+				}
+			},
+			"json"
+		);
+	});
+
+	$("#toggleFreezePrimitives")
+	.button({
+		icons: {
+			primary: "ui-icon-circle-close"
+		}
+	})
+	.click(function() {
+		$.post(
+			starexecRoot + "services/admin/freezePrimitives",
+			{"frozen": !star.freezePrimitives},
+			function(returnCode) {
+				if (parseReturnCode(returnCode)) {
+					setTimeout(function() {document.location.reload(true)}, 1000);
 				}
 			},
 			"json"

--- a/WebContent/public/messages/error.jsp
+++ b/WebContent/public/messages/error.jsp
@@ -22,6 +22,9 @@
 		desc = "internal server error";
 		request.setAttribute("didLog", true);
 		break;
+	case 503:
+		desc = "service currently unavailable";
+		break;
 	default:
 		break;
 	}

--- a/WebContent/secure/add/benchmarks.jsp
+++ b/WebContent/secure/add/benchmarks.jsp
@@ -1,10 +1,16 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.data.database.Communities,org.starexec.data.database.Processors,org.starexec.data.database.Spaces,org.starexec.data.security.GeneralSecurity,org.starexec.data.to.DefaultSettings" %>
+        import="org.starexec.data.database.Communities,org.starexec.data.database.Processors,org.starexec.data.database.Spaces,org.starexec.data.security.GeneralSecurity,org.starexec.data.to.DefaultSettings, org.starexec.app.RESTHelpers" %>
 <%@page import="org.starexec.data.to.Permission, org.starexec.data.to.Processor, org.starexec.data.to.Space, org.starexec.data.to.enums.ProcessorType, org.starexec.util.SessionUtil, java.util.List" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
 	try {
+		if (RESTHelpers.freezePrimitives()) {
+			response.sendError(
+					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+					"Uploading benchmarks is temporarily disabled"
+			);
+		}
 		// Get parent space info for display
 		int spaceId = Integer.parseInt(request.getParameter("sid"));
 		DefaultSettings settings = Communities.getDefaultSettings(spaceId);

--- a/WebContent/secure/add/configuration.jsp
+++ b/WebContent/secure/add/configuration.jsp
@@ -7,7 +7,7 @@
 		if (RESTHelpers.freezePrimitives()) {
 			response.sendError(
 					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
-					"Uploading benchmarks is temporarily disabled"
+					"Uploading new solver configurations is temporarily disabled"
 			);
 		}
 		// Gather solver and user information

--- a/WebContent/secure/add/configuration.jsp
+++ b/WebContent/secure/add/configuration.jsp
@@ -1,9 +1,15 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB,org.starexec.data.database.Solvers,org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Solver, org.starexec.util.SessionUtil" %>
+        import="org.starexec.constants.DB,org.starexec.data.database.Solvers,org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Solver, org.starexec.util.SessionUtil, org.starexec.app.RESTHelpers" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
 	try {
+		if (RESTHelpers.freezePrimitives()) {
+			response.sendError(
+					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+					"Uploading benchmarks is temporarily disabled"
+			);
+		}
 		// Gather solver and user information
 		int solverId = Integer.parseInt(request.getParameter("sid"));
 		int userId = SessionUtil.getUserId(request);

--- a/WebContent/secure/add/solver.jsp
+++ b/WebContent/secure/add/solver.jsp
@@ -1,9 +1,15 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB,org.starexec.data.database.Settings,org.starexec.data.database.Spaces, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.DefaultSettings, org.starexec.data.to.Permission, org.starexec.util.SessionUtil, java.util.List" %>
+        import="org.starexec.constants.DB,org.starexec.data.database.Settings,org.starexec.data.database.Spaces, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.DefaultSettings, org.starexec.data.to.Permission, org.starexec.util.SessionUtil, java.util.List, org.starexec.app.RESTHelpers" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
 	try {
+		if (RESTHelpers.freezePrimitives()) {
+			response.sendError(
+					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+					"Uploading solvers is temporarily disabled"
+			);
+		}
 		// Get parent space info for display
 		int spaceId = Integer.parseInt(request.getParameter("sid"));
 		int userId = SessionUtil.getUserId(request);

--- a/WebContent/secure/admin/starexec.jsp
+++ b/WebContent/secure/admin/starexec.jsp
@@ -71,7 +71,7 @@
 			<ul id="actionList">
 				<li>
 					<button type="button" id="toggleFreezePrimitives">
-						${freezePrimitives ? "Freeze" : "Unfreeze"} Primitives
+						${freezePrimitives ? "Unfreeze" : "Freeze"} Primitives
 					</button>
 				</li>
 			</ul>

--- a/WebContent/secure/admin/starexec.jsp
+++ b/WebContent/secure/admin/starexec.jsp
@@ -1,9 +1,10 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.R" %>
+        import="org.starexec.constants.R, org.starexec.app.RESTHelpers" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%
 	try {
 		request.setAttribute("debugModeActive", R.DEBUG_MODE_ACTIVE);
+		request.setAttribute("freezePrimitives", RESTHelpers.freezePrimitives());
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
@@ -57,6 +58,27 @@
 						id="dialog-confirm-restart-txt"></span></p>
 			</div>
 			<p>Starexec revision ${buildVersion} built ${buildDate}</p>
+		</fieldset>
+		<fieldset>
+			<legend>freeze primitives</legend>
+			<p>
+				When frozen, no new solvers or benchmarks can be uploaded.
+				Solvers and benchmarks cannot be copied between spaces
+				(though they can still be <em>linked</em>).
+			</p><p>
+				This mode is designed to be used when migrating primitives to a new drive.
+			</p>
+			<ul id="actionList">
+				<li>
+					<button type="button" id="toggleFreezePrimitives">
+						${freezePrimitives ? "Freeze" : "Unfreeze"} Primitives
+					</button>
+				</li>
+			</ul>
+			<script>
+				var star = star || {};
+				star.freezePrimitives = ${freezePrimitives}
+			</script>
 		</fieldset>
 	</div>
 </star:template>

--- a/sql/SchemaChanges/00000003.sql
+++ b/sql/SchemaChanges/00000003.sql
@@ -1,0 +1,15 @@
+-- Add `freeze_primitives` system flag
+-- When this is set to TRUE, uploading Benchmarks and Solvers is disabled
+
+DROP PROCEDURE IF EXISTS UpdateTo2_3 //
+CREATE PROCEDURE UpdateTo2_3()
+BEGIN
+	IF EXISTS (SELECT 1 FROM system_flags WHERE major_version=1 AND minor_version=2) THEN
+		UPDATE system_flags SET minor_version=3;
+
+		ALTER TABLE system_flags ADD freeze_primitives BOOLEAN DEFAULT FALSE;
+	END IF;
+END //
+
+CALL UpdateTo2_3() //
+DROP PROCEDURE IF EXISTS UpdateTo2_3 //

--- a/sql/procedures/Misc.sql
+++ b/sql/procedures/Misc.sql
@@ -9,3 +9,15 @@ CREATE PROCEDURE LoginRecord(IN _userId INT, IN _ipAddress VARCHAR(15), IN _agen
 		INSERT INTO logins (user_id, login_date, ip_address, browser_agent)
 		VALUES (_userId, SYSDATE(), _ipAddress, _agent);
 	END //
+
+DROP PROCEDURE IF EXISTS SetFreezePrimitives //
+CREATE PROCEDURE SetFreezePrimitives(IN frozen BOOLEAN)
+	BEGIN
+		UPDATE system_flags SET freeze_primitives=frozen;
+	END //
+
+DROP PROCEDURE IF EXISTS GetFreezePrimitives //
+CREATE PROCEDURE GetFreezePrimitives()
+	BEGIN
+		SELECT freeze_primitives FROM system_flags;
+	END //

--- a/src/org/starexec/app/RESTHelpers.java
+++ b/src/org/starexec/app/RESTHelpers.java
@@ -2204,6 +2204,31 @@ public class RESTHelpers {
 		return "<span class='wallclockSum'>" + formattedWallclock + "</span>" + "<span class='cpuSum hidden'>" + formattedCpu + "</span>";
 	}
 
+	public static boolean freezePrimitives() throws SQLException {
+		return Common.query(
+				"{CALL GetFreezePrimitives()}",
+				procedure -> {},
+				results -> {
+					results.next();
+					return results.getBoolean("freeze_primitives");
+				}
+		);
+	}
+
+	public static void setFreezePrimitives(boolean frozen) throws SQLException {
+		log.info("setFreezePrimitives",
+			frozen
+			? "!!! Freezing Primitives !!!\n\tUploading Benchmarks and Solvers will be disabled"
+			: "!!! Unfreezing Primitives !!!\n\tUploading Benchmarks and Solvers will be allowed"
+		);
+		Common.update(
+				"{CALL SetFreezePrimitives(?)}",
+				procedure -> {
+					procedure.setBoolean(1, frozen);
+				}
+		);
+	}
+
 	/**
 	 * Represents a node in jsTree tree with certain attributes used for
 	 * displaying the node and obtaining information about the node.

--- a/src/org/starexec/app/RESTServices.java
+++ b/src/org/starexec/app/RESTServices.java
@@ -5163,4 +5163,26 @@ public class RESTServices {
 			throw RESTException.INTERNAL_SERVER_ERROR;
 		}
 	}
+
+	/**
+	 * @param frozen True to freeze primitives, false to unfreeze primitives
+	 * @param request HTTP request
+	 * @return a json string representing all the subspaces of the job space
+	 */
+	@POST
+	@Path("/admin/freezePrimitives")
+	@Produces("application/json")
+	public String freezePrimitives(@FormParam("frozen") boolean frozen, @Context HttpServletRequest request) {
+		int userId = SessionUtil.getUserId(request);
+		if (!GeneralSecurity.hasAdminWritePrivileges(userId)) {
+			return gson.toJson(new ValidatorStatusCode(true, "Only Admins can freeze or unfreeze primitives"));
+		}
+		try {
+			RESTHelpers.setFreezePrimitives(frozen);
+			return gson.toJson(new ValidatorStatusCode(true, "Uploading benchmarks and solvers is now " + (frozen ? "allowed" : "disallowed")));
+		} catch (SQLException e) {
+			log.error("freezePrimitives", e);
+			throw RESTException.INTERNAL_SERVER_ERROR;
+		}
+	}
 }

--- a/src/org/starexec/data/security/SolverSecurity.java
+++ b/src/org/starexec/data/security/SolverSecurity.java
@@ -1,6 +1,5 @@
 package org.starexec.data.security;
 
-import org.starexec.app.RESTHelpers;
 import org.starexec.data.database.Permissions;
 import org.starexec.data.database.Solvers;
 import org.starexec.data.database.Spaces;
@@ -12,7 +11,6 @@ import org.starexec.util.Util;
 import org.starexec.util.Validator;
 
 import java.io.File;
-import java.sql.SQLException;
 import java.util.List;
 
 public class SolverSecurity {
@@ -68,12 +66,8 @@ public class SolverSecurity {
 		if (!GeneralSecurity.hasAdminWritePrivileges(userId) && !(s.getUserId() == userId)) {
 			return new ValidatorStatusCode(false, "You do not have permission to add a configuration to this solver");
 		}
-		try {
-			if (RESTHelpers.freezePrimitives()) {
- 				return new ValidatorStatusCode(false, "Modifying solvers is currently disabled by the system administrator");
- 			}
- 		} catch (SQLException e) {
- 				return new ValidatorStatusCode(false, "Internal server error");
+		if (UploadSecurity.uploadsFrozen()) {
+ 			return new ValidatorStatusCode(false, "Modifying solvers is currently disabled by the system administrator");
  		}
 		return new ValidatorStatusCode(true);
 	}

--- a/src/org/starexec/data/security/SolverSecurity.java
+++ b/src/org/starexec/data/security/SolverSecurity.java
@@ -1,5 +1,6 @@
 package org.starexec.data.security;
 
+import org.starexec.app.RESTHelpers;
 import org.starexec.data.database.Permissions;
 import org.starexec.data.database.Solvers;
 import org.starexec.data.database.Spaces;
@@ -11,6 +12,7 @@ import org.starexec.util.Util;
 import org.starexec.util.Validator;
 
 import java.io.File;
+import java.sql.SQLException;
 import java.util.List;
 
 public class SolverSecurity {
@@ -66,6 +68,13 @@ public class SolverSecurity {
 		if (!GeneralSecurity.hasAdminWritePrivileges(userId) && !(s.getUserId() == userId)) {
 			return new ValidatorStatusCode(false, "You do not have permission to add a configuration to this solver");
 		}
+		try {
+			if (RESTHelpers.freezePrimitives()) {
+ 				return new ValidatorStatusCode(false, "Modifying solvers is currently disabled by the system administrator");
+ 			}
+ 		} catch (SQLException e) {
+ 				return new ValidatorStatusCode(false, "Internal server error");
+ 		}
 		return new ValidatorStatusCode(true);
 	}
 

--- a/src/org/starexec/data/security/SpaceSecurity.java
+++ b/src/org/starexec/data/security/SpaceSecurity.java
@@ -1,5 +1,6 @@
 package org.starexec.data.security;
 
+import org.starexec.app.RESTHelpers;
 import org.starexec.data.database.*;
 import org.starexec.data.to.*;
 import org.starexec.data.to.SolverBuildStatus.SolverBuildStatusCode;
@@ -744,6 +745,8 @@ public class SpaceSecurity {
 		Permission perm = Permissions.get(userId, spaceId);
 		if (perm == null || !perm.canAddSolver()) {
 			return new ValidatorStatusCode(false, "You do not have permission to add a solver to this space");
+		} else if (RESTHelpers.freezePrimitives()) {
+			return new ValidatorStatusCode(false, "Copying solvers is currently disabled by the system administrator");
 		}
 		return new ValidatorStatusCode(true);
 	}
@@ -760,6 +763,8 @@ public class SpaceSecurity {
 		Permission perm = Permissions.get(userId, spaceId);
 		if (perm == null || !perm.canAddBenchmark()) {
 			return new ValidatorStatusCode(false, "You do not have permission to add a benchmark to this space");
+		} else if (RESTHelpers.freezePrimitives()) {
+			return new ValidatorStatusCode(false, "Copying benchmarks is currently disabled by the system administrator");
 		}
 		return new ValidatorStatusCode(true);
 	}

--- a/src/org/starexec/data/security/SpaceSecurity.java
+++ b/src/org/starexec/data/security/SpaceSecurity.java
@@ -1,6 +1,5 @@
 package org.starexec.data.security;
 
-import org.starexec.app.RESTHelpers;
 import org.starexec.data.database.*;
 import org.starexec.data.to.*;
 import org.starexec.data.to.SolverBuildStatus.SolverBuildStatusCode;
@@ -745,7 +744,7 @@ public class SpaceSecurity {
 		Permission perm = Permissions.get(userId, spaceId);
 		if (perm == null || !perm.canAddSolver()) {
 			return new ValidatorStatusCode(false, "You do not have permission to add a solver to this space");
-		} else if (RESTHelpers.freezePrimitives()) {
+		} else if (UploadSecurity.uploadsFrozen()) {
 			return new ValidatorStatusCode(false, "Copying solvers is currently disabled by the system administrator");
 		}
 		return new ValidatorStatusCode(true);
@@ -763,7 +762,7 @@ public class SpaceSecurity {
 		Permission perm = Permissions.get(userId, spaceId);
 		if (perm == null || !perm.canAddBenchmark()) {
 			return new ValidatorStatusCode(false, "You do not have permission to add a benchmark to this space");
-		} else if (RESTHelpers.freezePrimitives()) {
+		} else if (UploadSecurity.uploadsFrozen()) {
 			return new ValidatorStatusCode(false, "Copying benchmarks is currently disabled by the system administrator");
 		}
 		return new ValidatorStatusCode(true);

--- a/src/org/starexec/data/security/SpaceSecurity.java
+++ b/src/org/starexec/data/security/SpaceSecurity.java
@@ -551,6 +551,10 @@ public class SpaceSecurity {
 	public static ValidatorStatusCode canCopyOrLinkBenchmarksBetweenSpaces(
 			Integer fromSpaceId, int toSpaceId, int userId, List<Integer> benchmarkIdsBeingCopied, boolean copy
 	) {
+		if (copy && UploadSecurity.uploadsFrozen()) {
+ 			return new ValidatorStatusCode(false, "Copying benchmarks is currently disabled by the system administrator");
+ 		}
+
 		boolean isAdmin = GeneralSecurity.hasAdminWritePrivileges(userId);
 		ValidatorStatusCode status = null;
 		if (fromSpaceId != null) {
@@ -608,6 +612,10 @@ public class SpaceSecurity {
 	) {
 		//if we are copying, but not linking, make sure the user has enough disk space
 		if (copy) {
+			if (UploadSecurity.uploadsFrozen()) {
+ 				return new ValidatorStatusCode(false, "Copying solvers is currently disabled by the system administrator");
+ 			}
+
 			List<Solver> solvers = Solvers.get(solverIdsBeingCopied);
 			int index = 0;
 			for (Solver s : solvers) {
@@ -744,8 +752,6 @@ public class SpaceSecurity {
 		Permission perm = Permissions.get(userId, spaceId);
 		if (perm == null || !perm.canAddSolver()) {
 			return new ValidatorStatusCode(false, "You do not have permission to add a solver to this space");
-		} else if (UploadSecurity.uploadsFrozen()) {
-			return new ValidatorStatusCode(false, "Copying solvers is currently disabled by the system administrator");
 		}
 		return new ValidatorStatusCode(true);
 	}
@@ -762,8 +768,6 @@ public class SpaceSecurity {
 		Permission perm = Permissions.get(userId, spaceId);
 		if (perm == null || !perm.canAddBenchmark()) {
 			return new ValidatorStatusCode(false, "You do not have permission to add a benchmark to this space");
-		} else if (UploadSecurity.uploadsFrozen()) {
-			return new ValidatorStatusCode(false, "Copying benchmarks is currently disabled by the system administrator");
 		}
 		return new ValidatorStatusCode(true);
 	}

--- a/src/org/starexec/data/security/UploadSecurity.java
+++ b/src/org/starexec/data/security/UploadSecurity.java
@@ -1,7 +1,10 @@
 package org.starexec.data.security;
 
+import org.starexec.app.RESTHelpers;
 import org.starexec.data.database.Uploads;
 import org.starexec.data.to.BenchmarkUploadStatus;
+
+import java.sql.SQLException;
 
 /**
  * Determines whether users have authorization to view BenchmarkUploadStatus data
@@ -24,5 +27,17 @@ public class UploadSecurity {
 			return new ValidatorStatusCode(false, "You may only view your own benchmark uploads");
 		}
 		return new ValidatorStatusCode(true);
+	}
+
+	/**
+	 * Check if uploads are currently frozen
+	 * @return True if uploads are currently prohibitted, false otherwise
+	 */
+	public static boolean uploadsFrozen() {
+		try {
+			return RESTHelpers.freezePrimitives();
+		} catch (SQLException e) {
+			return true;
+		}
 	}
 }

--- a/src/org/starexec/servlets/SaveConfiguration.java
+++ b/src/org/starexec/servlets/SaveConfiguration.java
@@ -49,6 +49,7 @@ public class SaveConfiguration extends HttpServlet {
 					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
 					"Uploading solver configurations is currently disabled"
 				);
+				return;
 			}
 
 			// Parameter validation

--- a/src/org/starexec/servlets/SaveConfiguration.java
+++ b/src/org/starexec/servlets/SaveConfiguration.java
@@ -4,6 +4,7 @@ import org.apache.commons.io.FileUtils;
 import org.starexec.constants.R;
 import org.starexec.data.database.Solvers;
 import org.starexec.data.security.GeneralSecurity;
+import org.starexec.data.security.UploadSecurity;
 import org.starexec.data.security.ValidatorStatusCode;
 import org.starexec.data.to.Configuration;
 import org.starexec.data.to.Solver;
@@ -43,6 +44,13 @@ public class SaveConfiguration extends HttpServlet {
 	protected void doPost(HttpServletRequest request, HttpServletResponse response)
 			throws ServletException, IOException {
 		try {
+			if (UploadSecurity.uploadsFrozen()) {
+				response.sendError(
+					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+					"Uploading solver configurations is currently disabled"
+				);
+			}
+
 			// Parameter validation
 			ValidatorStatusCode status = this.isValidRequest(request);
 			if (!status.isSuccess()) {

--- a/src/org/starexec/servlets/UploadBenchmark.java
+++ b/src/org/starexec/servlets/UploadBenchmark.java
@@ -69,6 +69,7 @@ public class UploadBenchmark extends HttpServlet {
 					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
 					"Uploading benchmarks is currently disabled"
 				);
+				return;
 			}
 
 			// Extract data from the multipart request

--- a/src/org/starexec/servlets/UploadBenchmark.java
+++ b/src/org/starexec/servlets/UploadBenchmark.java
@@ -4,6 +4,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.starexec.constants.R;
 import org.starexec.data.database.*;
+import org.starexec.data.security.UploadSecurity;
 import org.starexec.data.security.ValidatorStatusCode;
 import org.starexec.data.to.*;
 import org.starexec.exceptions.StarExecException;
@@ -63,6 +64,13 @@ public class UploadBenchmark extends HttpServlet {
 	protected void doPost(HttpServletRequest request, HttpServletResponse response)
 			throws ServletException, IOException {
 		try {
+			if (UploadSecurity.uploadsFrozen()) {
+				response.sendError(
+					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+					"Uploading benchmarks is currently disabled"
+				);
+			}
+
 			// Extract data from the multipart request
 			HashMap<String, Object> form = Util.parseMultipartRequest(request);
 			ValidatorStatusCode status = isRequestValid(form, request);

--- a/src/org/starexec/servlets/UploadConfiguration.java
+++ b/src/org/starexec/servlets/UploadConfiguration.java
@@ -4,6 +4,7 @@ import org.apache.tomcat.util.http.fileupload.servlet.ServletFileUpload;
 import org.starexec.constants.R;
 import org.starexec.data.database.Solvers;
 import org.starexec.data.security.SolverSecurity;
+import org.starexec.data.security.UploadSecurity;
 import org.starexec.data.security.ValidatorStatusCode;
 import org.starexec.data.to.Configuration;
 import org.starexec.data.to.Solver;
@@ -47,6 +48,13 @@ public class UploadConfiguration extends HttpServlet {
 			throws ServletException, IOException {
 		int userId = SessionUtil.getUserId(request);
 		try {
+			if (UploadSecurity.uploadsFrozen()) {
+				response.sendError(
+					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+					"Uploading solver configurations is currently disabled"
+				);
+			}
+
 			// Ensure request is a file upload request (i.e. a multipart request)
 			if (ServletFileUpload.isMultipartContent(request)) {
 

--- a/src/org/starexec/servlets/UploadConfiguration.java
+++ b/src/org/starexec/servlets/UploadConfiguration.java
@@ -53,6 +53,7 @@ public class UploadConfiguration extends HttpServlet {
 					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
 					"Uploading solver configurations is currently disabled"
 				);
+				return;
 			}
 
 			// Ensure request is a file upload request (i.e. a multipart request)

--- a/src/org/starexec/servlets/UploadSolver.java
+++ b/src/org/starexec/servlets/UploadSolver.java
@@ -79,6 +79,7 @@ public class UploadSolver extends HttpServlet {
 					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
 					"Uploading solvers is currently disabled"
 				);
+				return;
 			}
 
 			if (ServletFileUpload.isMultipartContent(request)) {

--- a/src/org/starexec/servlets/UploadSolver.java
+++ b/src/org/starexec/servlets/UploadSolver.java
@@ -9,6 +9,7 @@ import org.starexec.data.database.Reports;
 import org.starexec.data.database.Solvers;
 import org.starexec.data.database.Users;
 import org.starexec.data.security.JobSecurity;
+import org.starexec.data.security.UploadSecurity;
 import org.starexec.data.security.ValidatorStatusCode;
 import org.starexec.data.to.*;
 import org.starexec.data.to.Solver.ExecutableType;
@@ -72,6 +73,13 @@ public class UploadSolver extends HttpServlet {
 		try {
 			// If we're dealing with an upload request...
 			log.info("doPost begins");
+
+			if (UploadSecurity.uploadsFrozen()) {
+				response.sendError(
+					HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+					"Uploading solvers is currently disabled"
+				);
+			}
 
 			if (ServletFileUpload.isMultipartContent(request)) {
 				HashMap<String, Object> form = Util.parseMultipartRequest(request);


### PR DESCRIPTION
We need to add a feature to disable creation of new solvers and benchmarks.

We need to be able to turn this feature on/off without needing to redeploy.