### PR TITLE
Escape filename

### DIFF
--- a/src/org/starexec/util/Util.java
+++ b/src/org/starexec/util/Util.java
@@ -1135,6 +1135,11 @@ public class Util {
 	 * @return true if file is binary, false otherwise
 	 */
 	public static boolean isBinaryFile(File f) throws IOException {
-		return Util.executeCommand("file -bi "+f).contains("charset=binary");
+		final String[] command = {
+			"file",
+			"-bi",
+			f.getCanonicalPath()
+		};
+		return Util.executeCommand(command).contains("charset=binary");
 	}
 }


### PR DESCRIPTION
Instead of relying on `Runtime.exec` to tokenize the command for us, we can tokenize it ourself. This way, we do not need to worry about quoting or escaping the filename.

This avoids situations where a solver configuration contains a hyphen surrounded by spaces (` - `), which causes `file -bi` to wait for input from `stdin` which it doesn't get but instead hangs forever.

Tested with this modified solver: [`always-unsat-solver.zip`](https://github.com/StarExec/StarExec/files/2349606/always-unsat-solver.zip)