### PR TITLE
Update database on new install

### DIFF
--- a/build/build-sql.xml
+++ b/build/build-sql.xml
@@ -20,6 +20,7 @@
 		</pathconvert>
 		<pathconvert property="sqlProcedures" pathsep="${line.separator}source ">
 			<path>
+				<fileset dir="sql/SchemaChanges" includes="**/*.sql" />
 				<fileset dir="sql/procedures" includes="**/*.sql" />
 				<fileset dir="sql" includes="StarFunctions.sql" />
 			</path>


### PR DESCRIPTION
Now that `NewInstall.sql` has diverged from our current schema, we should run all schema updates when setting up a new database.