### PR TITLE
Each StarDev instance should have its own R.java

### DIFF
--- a/build/build-compile.xml
+++ b/build/build-compile.xml
@@ -11,11 +11,11 @@
 		<!-- Compile the source code to get the java classes -->
 		<javac debug="true" debuglevel="lines,vars,source" destdir="${class-dir}" classpathref="classpath" nowarn="on">
 			<src path="src" />
-			<src path="${java.io.tmpdir}" />
+			<src path="${java.io.tmpdir}/${STAREXEC_APPNAME}" />
 			<compilerarg value="-Xlint:unchecked"/>
 			<include name="org/starexec/**/*.java" />
 			<include name="R.java" />
-			<exclude name="**/constants/R.java" />
+			<exclude name="org/starexec/constants/R.java" />
 		</javac>
 		<property name="starexec-already-compiled" value="true" />
 	</target>

--- a/build/build-config.xml
+++ b/build/build-config.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <project name="config" basedir=".">
 	<target name="config" depends="register-commands">
-		<delete file="${java.io.tmpdir}/R.java" quiet="true" />
-		<copy file="src/org/starexec/constants/R.java" tofile="${java.io.tmpdir}/R.java">
+		<delete file="${java.io.tmpdir}/${STAREXEC_APPNAME}/R.java" quiet="true" />
+		<mkdir dir="${java.io.tmpdir}/${STAREXEC_APPNAME}" />
+		<copy file="src/org/starexec/constants/R.java" tofile="${java.io.tmpdir}/${STAREXEC_APPNAME}/R.java">
 			<filterset>
 				<filter token="Backend.Root"          value="${Backend.Root}"/>
 				<filter token="Backend.Type"          value="${Backend.Type}"/>

--- a/build/build-starexeccommand.xml
+++ b/build/build-starexeccommand.xml
@@ -12,7 +12,7 @@
 	<target name="compilestarcom" depends="config,cleanstarcom" unless="starexec-already-compiled">
 		<javac debug="true" debuglevel="lines,vars,source" destdir="${starcom-comp}" classpathref="starcomclasspath" nowarn="on">
 			<src path="${source-dir}"/>
-			<src path="${java.io.tmpdir}"/>
+			<src path="${java.io.tmpdir}/${STAREXEC_APPNAME}"/>
 			<include name="R.java"/>
 			<include name="org/starexec/command/*.java"/>
 			<include name="org/starexec/data/to/Permission.java"/>
@@ -20,6 +20,7 @@
 			<include name="org/starexec/util/Validator.java"/>
 			<include name="org/starexec/backend/Backend.java"/>
 			<include name="org/starexec/util/ArchiveUtil.java"/>
+			<exclude name="org/starexec/constants/R.java" />
 		</javac>
 	</target>
 


### PR DESCRIPTION
Because R.java contains passwords, it must not be world-readable.
However, multiple StarDev instances will each need to save a `R.java` file. With this change, instead of StarDev only holding a single `R.java` file, each instance will have its own `R.java` file in `/tmp/starexec_NAME`