### PR TITLE
Permissions

### DIFF
--- a/build/build-sql.xml
+++ b/build/build-sql.xml
@@ -26,7 +26,6 @@
 			</path>
 			<map from="${basedir}/sql/" to=""/>
 		</pathconvert>
-		<mkdir dir="${data_dir}" />
 		<concat destfile="sql/NewInstall.sql">
 			<header>-- ${generated-message}${line.separator}</header>
 			<fileset file="sql/NewInstall.template" />

--- a/script/soft-deploy.template
+++ b/script/soft-deploy.template
@@ -26,10 +26,15 @@ rm -f $STAR_WAR
 mkdirIf() {
 if [ ! -d $1 ] ; then
   mkdir -p $1
-  chmod 775 $1
   chgrp star-web $1
+  chmod 775 $1
 fi
 }
+
+# We must create the data dir first (even though we are using `mkdir -p` to
+# ensure that it has the proper permissions. Without this line, we cannot be
+# sure that the data dir is a member of *star-web*
+mkdirIf $STAREXEC_DATA_DIR
 
 echo "Copying the GridEngine scripts to $SGE_SCRIPT_DIR"
 mkdirIf $SGE_SCRIPT_DIR

--- a/script/soft-deploy.template
+++ b/script/soft-deploy.template
@@ -26,6 +26,8 @@ rm -f $STAR_WAR
 mkdirIf() {
 if [ ! -d $1 ] ; then
   mkdir -p $1
+  chmod 775 $1
+  chgrp star-web $1
 fi
 }
 
@@ -51,9 +53,6 @@ echo "Creating data directories if they are not present already"
 for d in Benchmarks Solvers processor_scripts jobin jobxml jobout joboutput joboutput/logs batchSpace/uploads ; do
   mkdirIf $STAREXEC_DATA_DIR/$d
 done
-
-chgrp -fR star-web $STAREXEC_DATA_DIR
-chmod -fR g+rwx    $STAREXEC_DATA_DIR
 
 while [ -d $APPDIR ] ; do
   echo "waiting for tomcat to remove the app directory"


### PR DESCRIPTION
Since `data_dir` was being created (erroneously) by the `compile-sql` build step, it already existed before `soft-deploy.sh` had a chance to create it, which means it was left in place _with the wrong permissions_.

This has been an issue for quite some time, but we have always gotten around it by just manually setting permissions for that directory. With this change, developers should finally be able to successfully run `ant && ./script/soft-deploy.sh && ./script/newInstallWithTestData.sh` and get a working StarExec instance up and running.