### PR TITLE
Job name textbox now enforces the maxLength set in DB.java.

### DIFF
--- a/WebContent/secure/add/job.jsp
+++ b/WebContent/secure/add/job.jsp
@@ -110,7 +110,7 @@
 				    title="how do you want this job to be displayed in StarExec?">
 					<td class="label"><p>job name</p></td>
 					<td><input length="${jobNameLen}" id="txtJobName"
-					           name="name" type="text"
+					           name="name" type="text"  maxlength="<%= DB.JOB_NAME_LEN %>"
 					           value="${space.name} <fmt:formatDate pattern="yyyy-MM-dd HH.mm" value="${now}" />"/>
 					</td>
 				</tr>


### PR DESCRIPTION
Pattern was not enforced, a separate issue has been created for migrating enforcement from JavaScript to HTML.