### PR TITLE
Use `umask` to set file permissions

### DIFF
--- a/script/soft-deploy.template
+++ b/script/soft-deploy.template
@@ -2,6 +2,9 @@
 #
 # Run from the directory where you build starexec with ant (build.xml).
 
+# Files created by this script must be group read+write+execute
+umask -S g=rwx
+
 # filled in by running ant with build.xml:
 APPNAME=@STAREXEC_APPNAME@
 STAREXEC_DATA_DIR=@data_dir@
@@ -27,7 +30,6 @@ mkdirIf() {
 if [ ! -d $1 ] ; then
   mkdir -p $1
   chgrp star-web $1
-  chmod 775 $1
 fi
 }
 


### PR DESCRIPTION
We must ensure that any directories created with `mkdir -p` are readable
by the group `star-web`. By setting `umask` at the beginning of the
script, we ensure that any directories created in this context will be
group read+write+execute. The `umask` is limited to the scope of the
script, and will revert to what it was before after the script
terminates.

Unix is fun.