### PR TITLE
Inherit validation patterns from R.java

### DIFF
--- a/WebContent/js/accounts/password_reset.js
+++ b/WebContent/js/accounts/password_reset.js
@@ -19,12 +19,7 @@ function initUI() {
  */
 function attachFormValidation() {
 	// Adds regular expression handling to the jQuery Validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Form validation rules/messages	
 	$("#resetForm").validate({

--- a/WebContent/js/add/batchSpace.js
+++ b/WebContent/js/add/batchSpace.js
@@ -33,12 +33,7 @@ function initUI() {
 function attachFormValidation() {
 
 	// Adds regular expression handling to the validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Re-validate the 'file location' field when it loses focus
 	$("#fileUpload").change(function() {

--- a/WebContent/js/add/benchmarks.js
+++ b/WebContent/js/add/benchmarks.js
@@ -25,12 +25,7 @@ $(document).ready(function() {
 function attachFormValidation() {
 
 	// Add 'regex' method to JQuery validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	$("#radioLocal").change(function() {
 		if ($("#radioLocal").is(":checked")) {

--- a/WebContent/js/add/configuration.js
+++ b/WebContent/js/add/configuration.js
@@ -84,11 +84,11 @@ function attachFormValidation() {
 		rules: {
 			saveConfigName: {
 				required: true,
-				regex: "DUMMY REGEX"
+				jspregex: "DUMMY REGEX"
 			},
 			saveConfigDesc: {
 				maxlength: $("#saveConfigDesc").attr("maxlength"),
-				jsregex: getPrimDescRegex()
+				regex: getPrimDescRegex()
 			},
 			saveConfigContents: {
 				required: true
@@ -97,13 +97,13 @@ function attachFormValidation() {
 		messages: {
 			saveConfigName: {
 				required: "name required",
-				regex: "invalid characters"
+				jspregex: "invalid characters"
 			},
 			saveConfigDesc: {
 				required: "description required",
 				maxlength: "max length is " + $("#saveConfigDesc")
 				.attr("maxlength"),
-				jsregex: "invalid characters"
+				regex: "invalid characters"
 			},
 			saveConfigContents: {
 				required: "file can't be empty"

--- a/WebContent/js/add/configuration.js
+++ b/WebContent/js/add/configuration.js
@@ -41,12 +41,16 @@ function attachFormValidation() {
 
 	// Add regular expression handling to the JQuery validator
 	$.validator.addMethod(
-		"regex",
+		"jsregex",
 		function(value, element, regexp) {
 			var re = new RegExp(regexp);
 			return this.optional(element) || re.test(value);
 		});
-
+	$.validator.addMethod(
+		"regex",
+		function(value, element, str) {
+			return !element.validity.patternMismatch;
+		});
 	// Re-validate the 'file location' field when it loses focus
 	$("#configFile").change(function() {
 		$("#configFile").blur().focus();
@@ -60,11 +64,11 @@ function attachFormValidation() {
 			},
 			uploadConfigName: {
 				required: true,
-				regex: getPrimNameRegex()
+				regex: "DUMMY REGEX"
 			},
 			uploadConfigDesc: {
 				maxlength: $("#uploadConfigDesc").attr("maxlength"),
-				regex: getPrimDescRegex()
+				jsregex: getPrimDescRegex()
 			}
 		},
 		messages: {
@@ -79,7 +83,7 @@ function attachFormValidation() {
 				required: "description required",
 				maxlength: "max length is " + $("#uploadConfigDesc")
 				.attr("maxlength"),
-				regex: "invalid character(s)"
+				jsregex: "invalid character(s)"
 			}
 		}
 	});
@@ -89,11 +93,11 @@ function attachFormValidation() {
 		rules: {
 			saveConfigName: {
 				required: true,
-				regex: getPrimNameRegex()
+				regex: "DUMMY REGEX"
 			},
 			saveConfigDesc: {
 				maxlength: $("#saveConfigDesc").attr("maxlength"),
-				regex: getPrimDescRegex()
+				jsregex: getPrimDescRegex()
 			},
 			saveConfigContents: {
 				required: true
@@ -108,7 +112,7 @@ function attachFormValidation() {
 				required: "description required",
 				maxlength: "max length is " + $("#saveConfigDesc")
 				.attr("maxlength"),
-				regex: "invalid characters"
+				jsregex: "invalid characters"
 			},
 			saveConfigContents: {
 				required: "file can't be empty"

--- a/WebContent/js/add/configuration.js
+++ b/WebContent/js/add/configuration.js
@@ -40,17 +40,8 @@ function initUI() {
 function attachFormValidation() {
 
 	// Add regular expression handling to the JQuery validator
-	$.validator.addMethod(
-		"jsregex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
-	$.validator.addMethod(
-		"regex",
-		function(value, element, str) {
-			return !element.validity.patternMismatch;
-		});
+	addValidators();
+
 	// Re-validate the 'file location' field when it loses focus
 	$("#configFile").change(function() {
 		$("#configFile").blur().focus();
@@ -64,11 +55,11 @@ function attachFormValidation() {
 			},
 			uploadConfigName: {
 				required: true,
-				regex: "DUMMY REGEX"
+				jspregex: "DUMMY REGEX"
 			},
 			uploadConfigDesc: {
 				maxlength: $("#uploadConfigDesc").attr("maxlength"),
-				jsregex: getPrimDescRegex()
+				regex: getPrimDescRegex()
 			}
 		},
 		messages: {
@@ -77,13 +68,13 @@ function attachFormValidation() {
 			},
 			uploadConfigName: {
 				required: "name required",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			uploadConfigDesc: {
 				required: "description required",
 				maxlength: "max length is " + $("#uploadConfigDesc")
 				.attr("maxlength"),
-				jsregex: "invalid character(s)"
+				regex: "invalid character(s)"
 			}
 		}
 	});

--- a/WebContent/js/add/job.js
+++ b/WebContent/js/add/job.js
@@ -94,9 +94,8 @@ function attachFormValidation() {
 	// Add regular expression capabilities to the validator
 	$.validator.addMethod(
 		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
+		function(value, element, str) {
+			return element.validity.patternMismatch;
 		});
 	$.validator.addMethod(
 		"interval",
@@ -112,7 +111,7 @@ function attachFormValidation() {
 				required: true,
 				minlength: 2,
 				maxlength: $("#txtJobName").attr("length"),
-				regex: getPrimNameRegex()
+				regex: "DUMMY REGEX"
 			},
 			desc: {
 				required: false,

--- a/WebContent/js/add/job.js
+++ b/WebContent/js/add/job.js
@@ -93,9 +93,15 @@ function getClockTimeoutErrorMessage() {
 function attachFormValidation() {
 	// Add regular expression capabilities to the validator
 	$.validator.addMethod(
+		"jsregex",
+		function(value, element, str) {
+			var re = new RegExp(str);
+			return this.optional(element) || re.test(value);
+		});
+	$.validator.addMethod(
 		"regex",
 		function(value, element, str) {
-			return element.validity.patternMismatch;
+			return !element.validity.patternMismatch;
 		});
 	$.validator.addMethod(
 		"interval",
@@ -116,7 +122,7 @@ function attachFormValidation() {
 			desc: {
 				required: false,
 				maxlength: $("#txtDesc").attr("length"),
-				regex: getPrimDescRegex()
+				jsregex: getPrimDescRegex()
 			},
 			cpuTimeout: {
 				required: true,
@@ -151,7 +157,7 @@ function attachFormValidation() {
 			desc: {
 				required: "enter a job description",
 				maxlength: $("#txtDesc").attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jsregex: "invalid character(s)"
 			},
 			cpuTimeout: {
 				required: "enter a timeout",

--- a/WebContent/js/add/job.js
+++ b/WebContent/js/add/job.js
@@ -92,23 +92,7 @@ function getClockTimeoutErrorMessage() {
  */
 function attachFormValidation() {
 	// Add regular expression capabilities to the validator
-	$.validator.addMethod(
-		"jsregex",
-		function(value, element, str) {
-			var re = new RegExp(str);
-			return this.optional(element) || re.test(value);
-		});
-	$.validator.addMethod(
-		"regex",
-		function(value, element, str) {
-			return !element.validity.patternMismatch;
-		});
-	$.validator.addMethod(
-		"interval",
-		function(value, element, str) {
-			return value == 0 || value >= 10;
-		}
-	);
+	addValidators();
 
 	// Set up form validation
 	$("#addForm").validate({
@@ -117,12 +101,12 @@ function attachFormValidation() {
 				required: true,
 				minlength: 2,
 				maxlength: $("#txtJobName").attr("length"),
-				regex: "DUMMY REGEX"
+				jspregex: "DUMMY REGEX"
 			},
 			desc: {
 				required: false,
 				maxlength: $("#txtDesc").attr("length"),
-				jsregex: getPrimDescRegex()
+				regex: getPrimDescRegex()
 			},
 			cpuTimeout: {
 				required: true,
@@ -152,12 +136,12 @@ function attachFormValidation() {
 				minlength: "2 characters minimum",
 				maxlength: $("#txtJobName")
 				.attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			desc: {
 				required: "enter a job description",
 				maxlength: $("#txtDesc").attr("length") + " characters maximum",
-				jsregex: "invalid character(s)"
+				regex: "invalid character(s)"
 			},
 			cpuTimeout: {
 				required: "enter a timeout",

--- a/WebContent/js/add/picture.js
+++ b/WebContent/js/add/picture.js
@@ -20,12 +20,7 @@ function initUI() {
 function attachFormValidation() {
 
 	// Add regular expressions to the validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Re-validate the 'picture location' field when it loses focus
 	$("#uploadPic").change(function() {

--- a/WebContent/js/add/queue.js
+++ b/WebContent/js/add/queue.js
@@ -38,12 +38,7 @@ function initUI() {
 function attachFormValidation() {
 
 	// Add regular expression capabilities to the validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Set up form validation
 	$("#addForm").validate({

--- a/WebContent/js/add/quickJob.js
+++ b/WebContent/js/add/quickJob.js
@@ -40,17 +40,9 @@ function getClockTimeoutErrorMessage() {
  */
 function attachFormValidation() {
 	// Add regular expression capabilities to the validator
-	$.validator.addMethod(
-		"jsregex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
-	$.validator.addMethod(
-		"regex",
-		function(value, element, str) {
-			return !element.validity.patternMismatch;
-		});
+	
+	addValidators();
+
 	// Set up form validation
 	$("#addForm").validate({
 		submitHandler: function(form) {
@@ -65,12 +57,12 @@ function attachFormValidation() {
 				required: true,
 				minlength: 1,
 				maxlength: $("#txtJobName").attr("length"),
-				regex: "DUMMY REGEX"
+				jspregex: "DUMMY REGEX"
 			},
 			desc: {
 				required: false,
 				maxlength: $("#txtDesc").attr("length"),
-				jsregex: getPrimDescRegex()
+				regex: getPrimDescRegex()
 			},
 			cpuTimeout: {
 				required: true,
@@ -93,7 +85,7 @@ function attachFormValidation() {
 				required: true,
 				minlength: 1,
 				maxlength: $("#txtBenchName").attr("length"),
-				regex: "DUMMY REGEX"
+				jspregex: "DUMMY REGEX"
 			},
 			bench: {
 				required: true,
@@ -121,14 +113,14 @@ function attachFormValidation() {
 				minlength: "1 character minimum",
 				maxlength: $("#txtJobName")
 				.attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			benchName: {
 				required: "enter a benchmark name",
 				minlength: "1 character minimum",
 				maxlength: $("#txtBenchName")
 				.attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			bench: {
 				required: "enter a benchmark",
@@ -137,7 +129,7 @@ function attachFormValidation() {
 			desc: {
 				required: "enter a job description",
 				maxlength: $("#txtDesc").attr("length") + " characters maximum",
-				jsregex: "invalid character(s)"
+				regex: "invalid character(s)"
 			},
 			cpuTimeout: {
 				required: "enter a timeout",

--- a/WebContent/js/add/quickJob.js
+++ b/WebContent/js/add/quickJob.js
@@ -41,12 +41,16 @@ function getClockTimeoutErrorMessage() {
 function attachFormValidation() {
 	// Add regular expression capabilities to the validator
 	$.validator.addMethod(
-		"regex",
+		"jsregex",
 		function(value, element, regexp) {
 			var re = new RegExp(regexp);
 			return this.optional(element) || re.test(value);
 		});
-
+	$.validator.addMethod(
+		"regex",
+		function(value, element, str) {
+			return !element.validity.patternMismatch;
+		});
 	// Set up form validation
 	$("#addForm").validate({
 		submitHandler: function(form) {
@@ -61,12 +65,12 @@ function attachFormValidation() {
 				required: true,
 				minlength: 1,
 				maxlength: $("#txtJobName").attr("length"),
-				regex: getPrimNameRegex()
+				regex: "DUMMY REGEX"
 			},
 			desc: {
 				required: false,
 				maxlength: $("#txtDesc").attr("length"),
-				regex: getPrimDescRegex()
+				jsregex: getPrimDescRegex()
 			},
 			cpuTimeout: {
 				required: true,
@@ -89,7 +93,7 @@ function attachFormValidation() {
 				required: true,
 				minlength: 1,
 				maxlength: $("#txtBenchName").attr("length"),
-				regex: getPrimNameRegex()
+				regex: "DUMMY REGEX"
 			},
 			bench: {
 				required: true,
@@ -133,7 +137,7 @@ function attachFormValidation() {
 			desc: {
 				required: "enter a job description",
 				maxlength: $("#txtDesc").attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jsregex: "invalid character(s)"
 			},
 			cpuTimeout: {
 				required: "enter a timeout",

--- a/WebContent/js/add/solver.js
+++ b/WebContent/js/add/solver.js
@@ -111,12 +111,16 @@ function attachFormValidation() {
 
 	// Add regular expression handler to jQuery validator
 	$.validator.addMethod(
-		"regex",
+		"jsregex",
 		function(value, element, regexp) {
 			var re = new RegExp(regexp);
 			return this.optional(element) || re.test(value);
 		});
-
+	$.validator.addMethod(
+		"regex",
+		function(value, element, str) {
+			return !element.validity.patternMismatch;	
+		});
 	// Re-validate the 'solver location' field when it loses focus
 	$("#fileLoc").change(function() {
 		$("#fileLoc").blur().focus();
@@ -127,33 +131,33 @@ function attachFormValidation() {
 		rules: {
 			f: {
 				required: "#radioLocal:checked",
-				regex: "(\.tgz$)|(\.zip$)|(\.tar(\.gz)?$)"
+				jsregex: "(\.tgz$)|(\.zip$)|(\.tar(\.gz)?$)"
 			},
 			url: {
 				required: "#radioURL:checked",
-				regex: "(\.tgz$)|(\.zip$)|(\.tar(\.gz)?$)"
+				jsregex: "(\.tgz$)|(\.zip$)|(\.tar(\.gz)?$)"
 			},
 			sn: {
 				required: true,
 				maxlength: $("#name").attr("length"),
-				regex: getPrimNameRegex()
+				regex: "DUMMY REGEX"
 			},
 			desc: {
 				maxlength: $("#description").attr("length"),
-				regex: getPrimDescRegex()
+				jsregex: getPrimDescRegex()
 			},
 			d: {
-				regex: "(\.txt$)"
+				jsregex: "(\.txt$)"
 			}
 		},
 		messages: {
 			f: {
 				required: "please select a file",
-				regex: ".zip, .tar and .tar.gz only"
+				jsregex: ".zip, .tar and .tar.gz only"
 			},
 			url: {
 				required: "please enter a URL",
-				regex: "URL must be .zip, .tar, or .tar.gz"
+				jsregex: "URL must be .zip, .tar, or .tar.gz"
 			},
 			sn: {
 				required: "solver name required",
@@ -163,10 +167,10 @@ function attachFormValidation() {
 			desc: {
 				maxlength: $("#description")
 				.attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jsregex: "invalid character(s)"
 			},
 			d: {
-				regex: ".txt file only"
+				jsregex: ".txt file only"
 			}
 		},
 		submitHandler: function(form) {

--- a/WebContent/js/add/solver.js
+++ b/WebContent/js/add/solver.js
@@ -110,17 +110,8 @@ function attachFormValidation() {
 	});
 
 	// Add regular expression handler to jQuery validator
-	$.validator.addMethod(
-		"jsregex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
-	$.validator.addMethod(
-		"regex",
-		function(value, element, str) {
-			return !element.validity.patternMismatch;	
-		});
+	addValidators();
+
 	// Re-validate the 'solver location' field when it loses focus
 	$("#fileLoc").change(function() {
 		$("#fileLoc").blur().focus();
@@ -131,46 +122,46 @@ function attachFormValidation() {
 		rules: {
 			f: {
 				required: "#radioLocal:checked",
-				jsregex: "(\.tgz$)|(\.zip$)|(\.tar(\.gz)?$)"
+				regex: "(\.tgz$)|(\.zip$)|(\.tar(\.gz)?$)"
 			},
 			url: {
 				required: "#radioURL:checked",
-				jsregex: "(\.tgz$)|(\.zip$)|(\.tar(\.gz)?$)"
+				regex: "(\.tgz$)|(\.zip$)|(\.tar(\.gz)?$)"
 			},
 			sn: {
 				required: true,
 				maxlength: $("#name").attr("length"),
-				regex: "DUMMY REGEX"
+				jspregex: "DUMMY REGEX"
 			},
 			desc: {
 				maxlength: $("#description").attr("length"),
-				jsregex: getPrimDescRegex()
+				regex: getPrimDescRegex()
 			},
 			d: {
-				jsregex: "(\.txt$)"
+				regex: "(\.txt$)"
 			}
 		},
 		messages: {
 			f: {
 				required: "please select a file",
-				jsregex: ".zip, .tar and .tar.gz only"
+				regex: ".zip, .tar and .tar.gz only"
 			},
 			url: {
 				required: "please enter a URL",
-				jsregex: "URL must be .zip, .tar, or .tar.gz"
+				regex: "URL must be .zip, .tar, or .tar.gz"
 			},
 			sn: {
 				required: "solver name required",
 				maxlength: $("#name").attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			desc: {
 				maxlength: $("#description")
 				.attr("length") + " characters maximum",
-				jsregex: "invalid character(s)"
+				regex: "invalid character(s)"
 			},
 			d: {
-				jsregex: ".txt file only"
+				regex: ".txt file only"
 			}
 		},
 		submitHandler: function(form) {

--- a/WebContent/js/add/space.js
+++ b/WebContent/js/add/space.js
@@ -9,42 +9,32 @@ $(document).ready(function() {
 function attachFormValidation() {
 
 	// Adds regular expression handling to validator
-	$.validator.addMethod(
-		"jsregex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		}
-	);
-	$.validator.addMethod(
-		"regex",
-		function(value, element, str) {
-			return !element.validity.patternMismatch;
-		});
+	addValidators();
+
 	// Form validation rules/messages
 	$("#addForm").validate({
 		rules: {
 			name: {
 				required: true,
 				maxlength: $("#txtName").attr("length"),
-				regex: "DUMMY REGEX"
+				jspregex: "DUMMY REGEX"
 			},
 			desc: {
 				required: false,
 				maxlength: $("#txtDesc").attr("length"),
-				jsregex: getPrimDescRegex()
+				regex: getPrimDescRegex()
 			}
 		},
 		messages: {
 			name: {
 				required: "a name is required",
 				maxlength: $("#txtName").attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			desc: {
 				required: "description required",
 				maxlength: $("#txtDesc").attr("length") + " characters maximum",
-				jsregex: "invalid character(s)"
+				regex: "invalid character(s)"
 			}
 		}
 	});

--- a/WebContent/js/add/space.js
+++ b/WebContent/js/add/space.js
@@ -10,25 +10,29 @@ function attachFormValidation() {
 
 	// Adds regular expression handling to validator
 	$.validator.addMethod(
-		"regex",
+		"jsregex",
 		function(value, element, regexp) {
 			var re = new RegExp(regexp);
 			return this.optional(element) || re.test(value);
 		}
 	);
-
+	$.validator.addMethod(
+		"regex",
+		function(value, element, str) {
+			return !element.validity.patternMismatch;
+		});
 	// Form validation rules/messages
 	$("#addForm").validate({
 		rules: {
 			name: {
 				required: true,
 				maxlength: $("#txtName").attr("length"),
-				regex: getPrimNameRegex()
+				regex: "DUMMY REGEX"
 			},
 			desc: {
 				required: false,
 				maxlength: $("#txtDesc").attr("length"),
-				regex: getPrimDescRegex()
+				jsregex: getPrimDescRegex()
 			}
 		},
 		messages: {
@@ -40,7 +44,7 @@ function attachFormValidation() {
 			desc: {
 				required: "description required",
 				maxlength: $("#txtDesc").attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jsregex: "invalid character(s)"
 			}
 		}
 	});

--- a/WebContent/js/add/to_community.js
+++ b/WebContent/js/add/to_community.js
@@ -56,12 +56,7 @@ function monitorTextarea(textarea, defaultText) {
 function attachFormValidation() {
 
 	// Add regular expression method to JQuery validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Form validation
 	$("#inviteForm").validate({

--- a/WebContent/js/add/updateBenchmarks.js
+++ b/WebContent/js/add/updateBenchmarks.js
@@ -33,12 +33,7 @@ function initUI() {
 function attachFormValidation() {
 
 	// Adds regular expression handling to the validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Re-validate the 'file location' field when it loses focus
 	$("#fileUpload").change(function() {

--- a/WebContent/js/add/user.js
+++ b/WebContent/js/add/user.js
@@ -20,12 +20,7 @@ function initUI() {
  */
 function attachFormValidation() {
 	// Adds regular expression handling to jQuery Validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	$("#regForm").validate({
 		rules: {

--- a/WebContent/js/admin/moveNodes.js
+++ b/WebContent/js/admin/moveNodes.js
@@ -50,12 +50,7 @@ function initUI() {
 function attachFormValidation() {
 
 	// Add regular expression capabilities to the validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Set up form validation
 	$("#addForm").validate({
@@ -64,7 +59,7 @@ function attachFormValidation() {
 				required: true,
 				minlength: 2,
 				maxlength: $("#txtQueueName").attr("length"),
-				regex: getPrimNameRegex()
+				jspregex: "DUMMY REGEX"
 			}
 		},
 		messages: {
@@ -73,7 +68,7 @@ function attachFormValidation() {
 				minlength: "2 characters minimum",
 				maxlength: $("#txtQueueName")
 				.attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			}
 		}
 	});

--- a/WebContent/js/admin/stressTest.js
+++ b/WebContent/js/admin/stressTest.js
@@ -29,6 +29,8 @@ function initUI() {
  */
 function attachFormValidation() {
 
+	addValidators();
+
 	// Add validation to the configuration save form
 	$("#saveConfigForm").validate({
 		rules: {

--- a/WebContent/js/edit/account.js
+++ b/WebContent/js/edit/account.js
@@ -13,6 +13,8 @@ $(document).ready(function() {
  * Attaches form validation to the 'change password' fields
  */
 function attachFormValidation() {
+	addValidators();
+
 	// Hide the password strength meter initially and display it when a password's
 	// strength has been calculated
 	$.validator.passwordStrengthMeter("#pwd-meter");

--- a/WebContent/js/edit/benchmark.js
+++ b/WebContent/js/edit/benchmark.js
@@ -33,12 +33,7 @@ function attachFormValidation() {
 	});
 
 	// Adds regular expression handling to validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Form validation rules/messages
 	$("#editBenchmarkForm").validate({
@@ -46,7 +41,7 @@ function attachFormValidation() {
 			name: {
 				required: true,
 				maxlength: $("#name").attr("maxlength"),
-				regex: getPrimNameRegex()
+				jspregex: "DUMMY REGEX"
 			},
 			description: {
 				maxlength: $("#description").attr("length"),
@@ -57,7 +52,7 @@ function attachFormValidation() {
 			name: {
 				required: "name required",
 				maxlength: $("#name").attr("maxlength") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			description: {
 				maxlength: $("#description")

--- a/WebContent/js/edit/community.js
+++ b/WebContent/js/edit/community.js
@@ -381,12 +381,7 @@ function attachFormValidation() {
 	});
 
 	// Adds regular expression handling to JQuery validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	var formsToValidate = [
 		'#addPostProcessorForm',
@@ -401,7 +396,7 @@ function attachFormValidation() {
 				name: {
 					required: true,
 					maxlength: $("#procName").attr("length"),
-					regex: getPrimNameRegex()
+					jspregex: "DUMMY REGEX"
 				},
 				desc: {
 					maxlength: $("#procDesc").attr("length"),
@@ -416,7 +411,7 @@ function attachFormValidation() {
 					required: "enter a processor name",
 					maxlength: $("#procName")
 					.attr("length") + " characters maximum",
-					regex: "invalid character(s)"
+					jspregex: "invalid character(s)"
 				},
 				desc: {
 					required: "enter a processor description",

--- a/WebContent/js/edit/configuration.js
+++ b/WebContent/js/edit/configuration.js
@@ -59,12 +59,7 @@ function attachFormValidation() {
 	});
 
 	// Adds regular expression 'regex' function to validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Form validation rules/messages
 	$("#editConfigForm").validate({
@@ -72,7 +67,7 @@ function attachFormValidation() {
 			name: {
 				required: true,
 				maxlength: $("#name").attr("maxlength"),
-				regex: getPrimNameRegex()
+				jspregex: "DUMMY REGEX"
 			},
 			description: {
 				maxlength: $("#description").attr("length"),
@@ -86,7 +81,7 @@ function attachFormValidation() {
 			name: {
 				required: "name required",
 				maxlength: $("#name").attr("maxlength") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			description: {
 				required: "description required",

--- a/WebContent/js/edit/processor.js
+++ b/WebContent/js/edit/processor.js
@@ -6,13 +6,7 @@ jQuery(function($) {
 	var $editProcForm = $("#editProcForm");
 
 	// Adds regular expression 'regex' function to validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		}
-	);
+	addValidators();
 
 	// Pressing the enter key on an input field triggers a submit,
 	// and this special validation process doesn't use submit, so
@@ -27,7 +21,7 @@ jQuery(function($) {
 			name: {
 				required: true,
 				maxlength: $name.attr("maxlength"),
-				regex: getPrimNameRegex()
+				jspregex: "DUMMY REGEX"
 			},
 			description: {
 				required: true,
@@ -39,7 +33,7 @@ jQuery(function($) {
 			name: {
 				required: "name required",
 				maxlength: $name.attr("maxlength") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			description: {
 				required: "description required",

--- a/WebContent/js/edit/queue.js
+++ b/WebContent/js/edit/queue.js
@@ -21,6 +21,9 @@ function initUI() {
 }
 
 function attachFormValidation() {
+	
+	addValidators();
+
 	// Pressing the enter key on an input field triggers a submit,
 	// and this special validation process doesn't use submit, so
 	// the following code prevents that trigger

--- a/WebContent/js/edit/solver.js
+++ b/WebContent/js/edit/solver.js
@@ -51,12 +51,7 @@ function attachFormValidation() {
 	});
 
 	// Adds regular expression handling to JQuery's validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Form validation rules/messages
 	$("#editSolverForm").validate({
@@ -64,7 +59,7 @@ function attachFormValidation() {
 			name: {
 				required: true,
 				maxlength: $("#name").attr("length"),
-				regex: getPrimNameRegex()
+				jspregex: getPrimNameRegex()
 			},
 			description: {
 				required: false,
@@ -76,7 +71,7 @@ function attachFormValidation() {
 			name: {
 				required: "name required",
 				maxlength: $("#name").attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			description: {
 				required: "description required",

--- a/WebContent/js/edit/space.js
+++ b/WebContent/js/edit/space.js
@@ -35,12 +35,7 @@ function attachFormValidation() {
 	});
 
 	// Adds regular expression handling to validator
-	$.validator.addMethod(
-		"regex",
-		function(value, element, regexp) {
-			var re = new RegExp(regexp);
-			return this.optional(element) || re.test(value);
-		});
+	addValidators();
 
 	// Form validation rules/messages
 	$("#editSpaceForm").validate({
@@ -48,7 +43,7 @@ function attachFormValidation() {
 			name: {
 				required: true,
 				maxlength: $("#name").attr("length"),
-				regex: getPrimNameRegex()
+				jspregex: "DUMMY REGEX"
 			},
 			description: {
 				required: false,
@@ -61,7 +56,7 @@ function attachFormValidation() {
 			name: {
 				required: "enter a space name",
 				maxlength: $("#name").attr("length") + " characters maximum",
-				regex: "invalid character(s)"
+				jspregex: "invalid character(s)"
 			},
 			description: {
 				required: "enter a description",

--- a/WebContent/js/master.js
+++ b/WebContent/js/master.js
@@ -319,6 +319,26 @@ function HtmlEncode(s) {
 	return s;
 }
 
+function addValidators() {
+	$.validator.addMethod(
+		"regex",
+		function(value, element, str) {
+			var re = new RegExp(str);
+			return this.optional(element) || re.test(value);
+		});
+	$.validator.addMethod(
+		"jspregex",
+		function(value, element, str) {
+			return !element.validity.patternMismatch;
+		});
+	$.validator.addMethod(
+		"interval",
+		function(value, element, str) {
+			return value == 0 || value >= 10;
+		}
+	);
+}
+
 /**
  * Returns the regular expression used to validate primitive names
  */

--- a/WebContent/secure/add/configuration.jsp
+++ b/WebContent/secure/add/configuration.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB,org.starexec.data.database.Solvers,org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Solver, org.starexec.util.SessionUtil, org.starexec.app.RESTHelpers" %>
+        import="org.starexec.constants.DB,org.starexec.constants.R,org.starexec.data.database.Solvers,org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Solver, org.starexec.util.SessionUtil, org.starexec.app.RESTHelpers" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
@@ -16,6 +16,7 @@
 		Solver solver = Solvers.get(solverId);
 		request.setAttribute("configNameLen", DB.CONFIGURATION_NAME_LEN - 4);
 		request.setAttribute("configDescLen", DB.CONFIGURATION_DESC_LEN);
+		request.setAttribute("namePattern", R.PRIMITIVE_NAME_PATTERN);
 		// Verify this user is the owner of the solver they are trying to upload configurations to
 		if (solver.getUserId() == userId ||
 				GeneralSecurity.hasAdminReadPrivileges(userId)) {
@@ -65,7 +66,7 @@
 				<tr>
 					<td>configuration name</td>
 					<td><input id="uploadConfigName" name="uploadConfigName"
-					           type="text" size="64"
+					           type="text" size="64" pattern="${namePattern}"
 					           maxlength="${configNameLen}"/></td>
 				</tr>
 				<tr>
@@ -96,7 +97,7 @@
 				<tr>
 					<td>configuration name</td>
 					<td><input id="saveConfigName" name="saveConfigName"
-					           type="text" size="64"
+					           type="text" size="64" pattern="${namePattern}"
 					           maxlength="${configNameLen}"/></td>
 				</tr>
 				<tr>

--- a/WebContent/secure/add/job.jsp
+++ b/WebContent/secure/add/job.jsp
@@ -69,6 +69,7 @@
 	request.setAttribute("JOB_NAME_LEN", DB.JOB_NAME_LEN);
 	request.setAttribute(
 			"MINIMUM_RESULTS_INTERVAL", R.MINIMUM_RESULTS_INTERVAL);
+	request.setAttribute("namePattern", R.PRIMITIVE_NAME_PATTERN);
 %>
 
 <jsp:useBean id="now" class="java.util.Date"/>
@@ -111,7 +112,7 @@
 				<tr class="noHover"
 				    title="how do you want this job to be displayed in StarExec?">
 					<td class="label"><p>job name</p></td>
-					<td><input length="${jobNameLen}" id="txtJobName" pattern="^[\\w\\-\\. \\+\\^=,!?:$%#@]+$"
+					<td><input length="${jobNameLen}" id="txtJobName" pattern="${namePattern}"
 					           name="name" type="text" maxlength="${JOB_NAME_LEN}"
 					           value="${space.name} <fmt:formatDate pattern="yyyy-MM-dd HH.mm" value="${now}" />"/>
 					</td>

--- a/WebContent/secure/add/job.jsp
+++ b/WebContent/secure/add/job.jsp
@@ -111,7 +111,7 @@
 				<tr class="noHover"
 				    title="how do you want this job to be displayed in StarExec?">
 					<td class="label"><p>job name</p></td>
-					<td><input length="${jobNameLen}" id="txtJobName"
+					<td><input length="${jobNameLen}" id="txtJobName" pattern="^[\\w\\-\\. \\+\\^=,!?:$%#@]+$"
 					           name="name" type="text" maxlength="${JOB_NAME_LEN}"
 					           value="${space.name} <fmt:formatDate pattern="yyyy-MM-dd HH.mm" value="${now}" />"/>
 					</td>

--- a/WebContent/secure/add/quickJob.jsp
+++ b/WebContent/secure/add/quickJob.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB,org.starexec.data.database.*,org.starexec.data.to.DefaultSettings, org.starexec.data.to.Permission,org.starexec.data.to.Processor, org.starexec.data.to.enums.ProcessorType, org.starexec.logger.StarLogger, org.starexec.servlets.CreateJob, org.starexec.util.SessionUtil" %>
+        import="org.starexec.constants.DB,org.starexec.constants.R,org.starexec.data.database.*,org.starexec.data.to.DefaultSettings, org.starexec.data.to.Permission,org.starexec.data.to.Processor, org.starexec.data.to.enums.ProcessorType, org.starexec.logger.StarLogger, org.starexec.servlets.CreateJob, org.starexec.util.SessionUtil" %>
 <%@ page import="java.util.List" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -35,6 +35,7 @@
 			request.setAttribute("jobNameLen", DB.JOB_NAME_LEN);
 			request.setAttribute("jobDescLen", DB.JOB_DESC_LEN);
 			request.setAttribute("benchNameLen", DB.BENCH_NAME_LEN);
+			request.setAttribute("namePattern", R.PRIMITIVE_NAME_PATTERN);
 			List<DefaultSettings> listOfDefaultSettings =
 					Settings.getDefaultSettingsVisibleByUser(userId);
 
@@ -117,7 +118,7 @@
 				<tr class="noHover"
 				    title="how do you want this job to be displayed in StarExec?">
 					<td class="label"><p>job name</p></td>
-					<td><input length="${jobNameLen}" id="txtJobName"
+					<td><input length="${jobNameLen}" id="txtJobName" pattern="${namePattern}"
 					           name="name" type="text"
 					           value="${spaceName} <fmt:formatDate pattern="MM-dd-yyyy HH.mm" value="${now}" />"/>
 					</td>
@@ -150,7 +151,7 @@
 				<tr class="noHover"
 				    title="what name would you like to give this benchmark in StarExec?">
 					<td class="label"><p>benchmark name</p></td>
-					<td><input length="${benchNameLen}" id="txtBenchName"
+					<td><input length="${benchNameLen}" id="txtBenchName" pattern="${namePattern}"
 					           name="benchName" type="text"
 					           value="${spaceName} <fmt:formatDate pattern="MM-dd-yyyy HH.mm" value="${now}" />"/>
 					</td>

--- a/WebContent/secure/add/solver.jsp
+++ b/WebContent/secure/add/solver.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB,org.starexec.data.database.Settings,org.starexec.data.database.Spaces, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.DefaultSettings, org.starexec.data.to.Permission, org.starexec.util.SessionUtil, java.util.List, org.starexec.app.RESTHelpers" %>
+        import="org.starexec.constants.DB,org.starexec.constants.R,org.starexec.data.database.Settings,org.starexec.data.database.Spaces, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.DefaultSettings, org.starexec.data.to.Permission, org.starexec.util.SessionUtil, java.util.List, org.starexec.app.RESTHelpers" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
@@ -14,7 +14,7 @@
 		int spaceId = Integer.parseInt(request.getParameter("sid"));
 		int userId = SessionUtil.getUserId(request);
 		request.setAttribute("space", Spaces.get(spaceId));
-
+		request.setAttribute("namePattern", R.PRIMITIVE_NAME_PATTERN);
 		request.setAttribute("solverNameLen", DB.SOLVER_NAME_LEN);
 		request.setAttribute("solverDescLen", DB.SOLVER_DESC_LEN);
 		// Verify this user can add spaces to this space
@@ -91,7 +91,7 @@
 				<tr>
 					<td>solver name</td>
 					<td><input id="name" name="sn" type="text" size="42"
-					           length="${solverNameLen}"/></td>
+					           pattern="${namePattern}" length="${solverNameLen}"/></td>
 				</tr>
 
 				<tr>

--- a/WebContent/secure/add/space.jsp
+++ b/WebContent/secure/add/space.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB,org.starexec.data.database.Spaces, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Permission, org.starexec.util.SessionUtil" %>
+        import="org.starexec.constants.DB,org.starexec.constants.R,org.starexec.data.database.Spaces, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Permission, org.starexec.util.SessionUtil" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
@@ -10,6 +10,7 @@
 		int userId = SessionUtil.getUserId(request);
 		request.setAttribute("isRoot", spaceId == 1);
 		request.setAttribute("space", Spaces.get(spaceId));
+		request.setAttribute("namePattern", R.PRIMITIVE_NAME_PATTERN);
 		request.setAttribute("nameLength", DB.SPACE_NAME_LEN);
 		request.setAttribute("descLength", DB.SPACE_DESC_LEN);
 		// Verify this user can add spaces to this space
@@ -54,7 +55,7 @@
 				<tbody>
 				<tr>
 					<td class="label"><p>name</p></td>
-					<td><input id="txtName" name="name" type="text"
+					<td><input id="txtName" name="name" type="text" pattern="${namePattern}"
 					           length="${nameLength}"></input></td>
 				</tr>
 				<tr>

--- a/WebContent/secure/admin/moveNodes.jsp
+++ b/WebContent/secure/admin/moveNodes.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB, org.starexec.data.database.Cluster, org.starexec.data.database.Queues, org.starexec.data.to.Queue, org.starexec.data.to.WorkerNode, java.util.List" %>
+        import="org.starexec.constants.DB, org.starexec.constants.R, org.starexec.data.database.Cluster, org.starexec.data.database.Queues, org.starexec.data.to.Queue, org.starexec.data.to.WorkerNode, java.util.List" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
@@ -11,6 +11,7 @@
 		request.setAttribute("queueNameLen", DB.QUEUE_NAME_LEN);
 		request.setAttribute("queueName", q.getName());
 		request.setAttribute("nodes", nodes);
+		request.setAttribute("nameRegex", R.PRIMITIVE_NAME_PATTERN);
 	} catch (NumberFormatException nfe) {
 		response.sendError(
 				HttpServletResponse.SC_BAD_REQUEST,
@@ -42,7 +43,7 @@
 				    title="what would you like to name your queue?">
 					<td class="label"><p>queue name</p></td>
 					<td>
-						<input type="hidden" name="name" value="${queueName}"/>
+						<input type="hidden" name="name" value="${queueName}" pattern="${nameRegex}"/>
 						<p>${queueName}</p></td>
 				</tr>
 				</tbody>

--- a/WebContent/secure/edit/benchmark.jsp
+++ b/WebContent/secure/edit/benchmark.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB,org.starexec.data.database.Benchmarks, org.starexec.data.database.Permissions, org.starexec.data.database.Processors, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Benchmark, org.starexec.data.to.enums.ProcessorType, org.starexec.util.SessionUtil" %>
+        import="org.starexec.constants.DB,org.starexec.constants.R,org.starexec.data.database.Benchmarks, org.starexec.data.database.Permissions, org.starexec.data.database.Processors, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Benchmark, org.starexec.data.to.enums.ProcessorType, org.starexec.util.SessionUtil" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
@@ -9,6 +9,7 @@
 		int benchId = Integer.parseInt(request.getParameter("id"));
 		request.setAttribute("benchNameLen", DB.BENCH_NAME_LEN);
 		request.setAttribute("benchDescLen", DB.BENCH_DESC_LEN);
+		request.setAttribute("nameRegex", R.PRIMITIVE_NAME_PATTERN);
 		Benchmark b = null;
 		if (Permissions.canUserSeeBench(benchId, userId)) {
 			b = Benchmarks.get(benchId);
@@ -83,7 +84,7 @@
 					<td class="label">name</td>
 					<td>
 						<input id="name" type="text" name="name"
-						       value="${bench.name}"
+						       value="${bench.name}" pattern="${nameRegex}"
 						       maxlength="${benchNameLen}"/>
 					</td>
 				</tr>

--- a/WebContent/secure/edit/community.jsp
+++ b/WebContent/secure/edit/community.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB,org.starexec.data.database.*, org.starexec.data.security.GeneralSecurity,org.starexec.data.to.*, org.starexec.data.to.Website.WebsiteType, org.starexec.data.to.enums.BenchmarkingFramework, org.starexec.data.to.enums.ProcessorType, org.starexec.util.SessionUtil"
+        import="org.starexec.constants.R,org.starexec.constants.DB,org.starexec.data.database.*, org.starexec.data.security.GeneralSecurity,org.starexec.data.to.*, org.starexec.data.to.Website.WebsiteType, org.starexec.data.to.enums.BenchmarkingFramework, org.starexec.data.to.enums.ProcessorType, org.starexec.util.SessionUtil"
         session="true" %>
 <%@ page import="org.starexec.util.Util, java.util.List" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
@@ -16,6 +16,7 @@
 		request.setAttribute("processorDescLen", DB.PROCESSOR_DESC_LEN);
 		request.setAttribute("benchNameLen", DB.BENCH_NAME_LEN);
 		request.setAttribute("benchDescLen", DB.BENCH_DESC_LEN);
+		request.setAttribute("nameRegex", R.PRIMITIVE_NAME_PATTERN);
 
 		int id = Integer.parseInt((String) request.getParameter("cid"));
 		request.setAttribute(
@@ -216,7 +217,7 @@
 			<table id="newTypeTbl">
 				<tr>
 					<td><label for="typeName">name</label></td>
-					<td><input name="name" type="text" id="typeName"/></td>
+					<td><input name="name" type="text" id="typeName" pattern="${nameRegex}"/></td>
 				</tr>
 				<tr>
 					<td><label for="typeDesc">description</label></td>

--- a/WebContent/secure/edit/configuration.jsp
+++ b/WebContent/secure/edit/configuration.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.apache.commons.io.FileUtils,org.starexec.constants.DB, org.starexec.data.database.Solvers, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Configuration, org.starexec.data.to.Solver, org.starexec.util.SessionUtil, org.starexec.util.Util, java.io.File"
+        import="org.apache.commons.io.FileUtils,org.starexec.constants.R,org.starexec.constants.DB, org.starexec.data.database.Solvers, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Configuration, org.starexec.data.to.Solver, org.starexec.util.SessionUtil, org.starexec.util.Util, java.io.File"
         session="true" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -9,6 +9,7 @@
 		// Grab relevant user id & configuration info
 		request.setAttribute("configNameLen", DB.CONFIGURATION_NAME_LEN);
 		request.setAttribute("configDescLen", DB.CONFIGURATION_DESC_LEN);
+		request.setAttribute("nameRegex", R.PRIMITIVE_NAME_PATTERN);
 		int configId = Integer.parseInt((String) request.getParameter("id"));
 		int userId = SessionUtil.getUserId(request);
 		Configuration con = Solvers.getConfiguration(configId);
@@ -72,7 +73,7 @@
 				<tr>
 					<td>name</td>
 					<td><input id="name" type="text" name="name"
-					           maxlength="${configNameLen}"
+					           maxlength="${configNameLen}" pattern="${nameRegex}"
 					           value="${config.name}"/></td>
 				</tr>
 				<tr>

--- a/WebContent/secure/edit/processor.jsp
+++ b/WebContent/secure/edit/processor.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB, org.starexec.data.database.Communities, org.starexec.data.database.Processors, org.starexec.data.database.Syntaxes, org.starexec.data.security.GeneralSecurity, org.starexec.data.security.ProcessorSecurity, org.starexec.data.to.DefaultSettings, org.starexec.data.to.Processor, org.starexec.data.to.Syntax, org.starexec.data.to.enums.Primitive, org.starexec.data.to.enums.ProcessorType, org.starexec.util.SessionUtil"
+        import="org.starexec.constants.DB, org.starexec.constants.R, org.starexec.data.database.Communities, org.starexec.data.database.Processors, org.starexec.data.database.Syntaxes, org.starexec.data.security.GeneralSecurity, org.starexec.data.security.ProcessorSecurity, org.starexec.data.to.DefaultSettings, org.starexec.data.to.Processor, org.starexec.data.to.Syntax, org.starexec.data.to.enums.Primitive, org.starexec.data.to.enums.ProcessorType, org.starexec.util.SessionUtil"
         session="true" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -8,6 +8,7 @@
 		// Grab relevant user id & processor info
 		request.setAttribute("processorNameLen", DB.PROCESSOR_NAME_LEN);
 		request.setAttribute("processorDescLen", DB.PROCESSOR_DESC_LEN);
+		request.setAttribute("nameRegex", R.PRIMITIVE_NAME_PATTERN);
 		int procId = Integer.parseInt((String) request.getParameter("id"));
 		int userId = SessionUtil.getUserId(request);
 		Processor proc = Processors.get(procId);
@@ -84,7 +85,7 @@
 				<tr>
 					<td class="label">name</td>
 					<td><input id="name" type="text" name="name"
-					           maxlength="${processorNameLen}"
+					           maxlength="${processorNameLen}" pattern="${nameRegex}"
 					           value="${proc.name}"/></td>
 				</tr>
 				<tr>

--- a/WebContent/secure/edit/solver.jsp
+++ b/WebContent/secure/edit/solver.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB,org.starexec.data.database.Permissions, org.starexec.data.database.Solvers,org.starexec.data.database.Websites, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Solver, org.starexec.data.to.Website.WebsiteType, org.starexec.util.SessionUtil" %>
+        import="org.starexec.constants.DB,org.starexec.constants.R,org.starexec.data.database.Permissions, org.starexec.data.database.Solvers,org.starexec.data.database.Websites, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Solver, org.starexec.data.to.Website.WebsiteType, org.starexec.util.SessionUtil" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
@@ -9,6 +9,7 @@
 		int solverId = Integer.parseInt(request.getParameter("id"));
 		request.setAttribute("solverNameLen", DB.SOLVER_NAME_LEN);
 		request.setAttribute("solverDescLen", DB.SOLVER_DESC_LEN);
+		request.setAttribute("nameRegex", R.PRIMITIVE_NAME_PATTERN);
 		Solver s = null;
 		if (Permissions.canUserSeeSolver(solverId, userId)) {
 			s = Solvers.get(solverId);
@@ -82,7 +83,7 @@
 				<tr>
 					<td class="label">solver name</td>
 					<td>
-						<input id="name" type="text" name="name"
+						<input id="name" type="text" name="name" pattern="${nameRegex}"
 						       value="${solver.name}">
 
 					</td>

--- a/WebContent/secure/edit/space.jsp
+++ b/WebContent/secure/edit/space.jsp
@@ -1,5 +1,5 @@
 <%@page contentType="text/html" pageEncoding="UTF-8"
-        import="org.starexec.constants.DB,org.starexec.data.database.Communities, org.starexec.data.database.Permissions, org.starexec.data.database.Spaces, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Permission, org.starexec.data.to.Space, org.starexec.util.SessionUtil" %>
+        import="org.starexec.constants.DB, org.starexec.constants.R, org.starexec.data.database.Communities, org.starexec.data.database.Permissions, org.starexec.data.database.Spaces, org.starexec.data.security.GeneralSecurity, org.starexec.data.to.Permission, org.starexec.data.to.Space, org.starexec.util.SessionUtil" %>
 <%@taglib prefix="star" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
@@ -8,6 +8,7 @@
 		int spaceId = Integer.parseInt(request.getParameter("id"));
 		request.setAttribute("nameLength", DB.SPACE_NAME_LEN);
 		request.setAttribute("descLength", DB.SPACE_DESC_LEN);
+		request.setAttribute("nameRegex", R.PRIMITIVE_NAME_PATTERN);
 		Space s = null;
 		if (Permissions.canUserSeeSpace(spaceId, userId)) {
 			s = Spaces.get(spaceId);
@@ -107,7 +108,7 @@
 				<tbody>
 				<tr>
 					<td class="label">space name</td>
-					<td><input id="name" type="text" name="name"
+					<td><input id="name" type="text" name="name" pattern="${nameRegex}"
 					           value="${space.name}" length="${nameLength}">
 					</td>
 				</tr>


### PR DESCRIPTION
All of the "add" pages have their regular expressions checked via the pattern attribute if the expression used to check them is found in R.java or DB.java (and the element supports it-- textarea doesn't support the pattern attribute)

This could eventually be extended to all pages on the site.

Closes #196