### PR TITLE
Fix adding/deleting JobPairs when not in Migration Mode

### DIFF
--- a/src/org/starexec/servlets/AddJobPairs.java
+++ b/src/org/starexec/servlets/AddJobPairs.java
@@ -82,7 +82,7 @@ public class AddJobPairs extends HttpServlet {
 				return;
 			}
 
-			if (!(Jobs.isReadOnly(jobId))) {
+			if (Jobs.isReadOnly(jobId)) {
 				response.sendError(
 						HttpServletResponse.SC_FORBIDDEN, "Job is readonly while in Migration Mode");
 				return;


### PR DESCRIPTION
It looks like our condition here is backwards. This is why it is currently not possible to add or remove JobPairs from jobs.

/cc: @ajreynol