### PR TITLE
Sanitize string in CSV

### DIFF
--- a/src/org/starexec/servlets/Download.java
+++ b/src/org/starexec/servlets/Download.java
@@ -459,7 +459,11 @@ public class Download extends HttpServlet {
 							/* we skip printing the starexec-result, and starexec-expected-result attributes,
 							   because we printed them already */
 							sb.append(",");
-							sb.append(props.getProperty(attr, "-"));
+							sb.append(
+								Util.escapeForCSV(
+									props.getProperty(attr, "-")
+								)
+							);
 						}
 					}
 				}

--- a/src/org/starexec/test/junit/UtilTests.java
+++ b/src/org/starexec/test/junit/UtilTests.java
@@ -104,4 +104,22 @@ public class UtilTests {
 		Assert.assertTrue(textFile.exists());
 		Assert.assertFalse(Util.isBinaryFile(textFile));
 	}
+
+	@Test
+	public void escapeForCSV() {
+		String escaped = "abc123";
+		String old;
+
+		old = "abc123";
+		Assert.assertTrue(Util.escapeForCSV(old).equals(escaped));
+
+		old = "abc,123";
+		Assert.assertTrue(Util.escapeForCSV(old).equals(escaped));
+
+		old = "abc\"123\"";
+		Assert.assertTrue(Util.escapeForCSV(old).equals(escaped));
+
+		old = ",,,,ab,c,12,,3,";
+		Assert.assertTrue(Util.escapeForCSV(old).equals(escaped));
+	}
 }

--- a/src/org/starexec/util/Util.java
+++ b/src/org/starexec/util/Util.java
@@ -1135,4 +1135,13 @@ public class Util {
 		};
 		return Util.executeCommand(command).contains("charset=binary");
 	}
+
+	/**
+	 * Escape a string for export to a CSV file
+	 * @param s String to escape
+	 * @return String with no quotes or commas
+	 */
+	public static String escapeForCSV(String s) {
+		return s.replaceAll("[,\"]+","");
+	}
 }


### PR DESCRIPTION
This will strip commas and quotation marks from strings before emitting them to a CSV.

Fixes #181