### PR TITLE
Do not modify created column

### DIFF
--- a/sql/SchemaChanges/00000005.sql
+++ b/sql/SchemaChanges/00000005.sql
@@ -5,7 +5,16 @@ CREATE PROCEDURE UpdateTo4_5()
 BEGIN
 	IF EXISTS (SELECT 1 FROM system_flags WHERE major_version=1 AND minor_version=4) THEN
 		UPDATE system_flags SET minor_version=5;
-		ALTER TABLE users CHANGE COLUMN created created timestamp DEFAULT NOW();
+		ALTER TABLE users              CHANGE COLUMN created     created     TIMESTAMP DEFAULT NOW();
+		ALTER TABLE spaces             CHANGE COLUMN created     created     TIMESTAMP DEFAULT NOW();
+		ALTER TABLE benchmarks         CHANGE COLUMN uploaded    uploaded    TIMESTAMP DEFAULT NOW();
+		ALTER TABLE solvers            CHANGE COLUMN uploaded    uploaded    TIMESTAMP DEFAULT NOW();
+		ALTER TABLE solver_pipelines   CHANGE COLUMN uploaded    uploaded    TIMESTAMP DEFAULT NOW();
+--		ALTER TABLE jobs               CHANGE COLUMN completed   completed   TIMESTAMP DEFAULT NOW();
+		ALTER TABLE verify             CHANGE COLUMN created     created     TIMESTAMP DEFAULT NOW();
+		ALTER TABLE community_requests CHANGE COLUMN created     created     TIMESTAMP DEFAULT NOW();
+		ALTER TABLE pass_reset_request CHANGE COLUMN created     created     TIMESTAMP DEFAULT NOW();
+		ALTER TABLE benchmark_uploads  CHANGE COLUMN upload_time upload_time TIMESTAMP DEFAULT NOW();
 	END IF;
 END //
 

--- a/sql/SchemaChanges/00000005.sql
+++ b/sql/SchemaChanges/00000005.sql
@@ -1,0 +1,13 @@
+-- Modify timestamp column so they are not updated automatically
+
+DROP PROCEDURE IF EXISTS UpdateTo4_5 //
+CREATE PROCEDURE UpdateTo4_5()
+BEGIN
+	IF EXISTS (SELECT 1 FROM system_flags WHERE major_version=1 AND minor_version=4) THEN
+		UPDATE system_flags SET minor_version=5;
+		ALTER TABLE users CHANGE COLUMN created created timestamp DEFAULT NOW();
+	END IF;
+END //
+
+CALL UpdateTo4_5() //
+DROP PROCEDURE IF EXISTS UpdateTo4_5 //


### PR DESCRIPTION
Currently, any column of type `timestamp` has its value set to `NOW()` any time the row is modified. This is not the expected behavior of the `users.created` column; we are trying to use it as the date a particular user account was created.

With this schema update, we will not modify this column automatically anymore.

Fixes #120