### PR TITLE
Archive Changes

### DIFF
--- a/src/org/starexec/util/ArchiveUtil.java
+++ b/src/org/starexec/util/ArchiveUtil.java
@@ -476,7 +476,7 @@ public class ArchiveUtil {
 	public static void createAndOutputZip(Iterable<File> paths, OutputStream output, String baseName) throws IOException {
 		String newFileName = baseName;
 		ZipArchiveOutputStream stream = new ZipArchiveOutputStream(output);
-		Collection<String> pathsSeen = new HashSet<>();
+		Map<String, Integer> pathsSeen = new HashMap<>();
 		for (File f : paths) {
 			log.debug("adding new file to zip = " + f.getAbsolutePath());
 			log.debug("directory status = " + f.isDirectory());
@@ -486,16 +486,24 @@ public class ArchiveUtil {
 				newFileName = baseName + File.separator + f.getName();
 			}
 
-			if (pathsSeen.contains(f.getAbsolutePath())) {
-				continue;
+			if (pathsSeen.containsKey(newFileName)) {
+				pathsSeen.put(newFileName, pathsSeen.get(newFileName) + 1);
 			} else {
-				pathsSeen.add(f.getAbsolutePath());
+				pathsSeen.put(newFileName, 1);
 			}
 
 			if (f.isDirectory()) {
-				addDirToArchive(stream, f, newFileName);
+				if(pathsSeen.get(newFileName) == 1) {
+					addDirToArchive(stream, f, newFileName);
+				} else {
+					addDirToArchive(stream, f, newFileName + "_" + pathsSeen.get(newFileName));
+				}
 			} else {
-				addFileToArchive(stream, f, newFileName);
+				if(pathsSeen.get(newFileName) == 1) {
+					addFileToArchive(stream, f, newFileName);
+				} else {
+					addFileToArchive(stream, f, newFileName + "_" +  pathsSeen.get(newFileName));
+				}
 			}
 		}
 		stream.finish();

--- a/src/org/starexec/util/ArchiveUtil.java
+++ b/src/org/starexec/util/ArchiveUtil.java
@@ -486,10 +486,10 @@ public class ArchiveUtil {
 				newFileName = baseName + File.separator + f.getName();
 			}
 
-			if (pathsSeen.contains(newFileName)) {
+			if (pathsSeen.contains(f.getAbsolutePath())) {
 				continue;
 			} else {
-				pathsSeen.add(newFileName);
+				pathsSeen.add(f.getAbsolutePath());
 			}
 
 			if (f.isDirectory()) {

--- a/src/org/starexec/util/ArchiveUtil.java
+++ b/src/org/starexec/util/ArchiveUtil.java
@@ -489,21 +489,13 @@ public class ArchiveUtil {
 			if (pathsSeen.containsKey(newFileName)) {
 				pathsSeen.put(newFileName, pathsSeen.get(newFileName) + 1);
 			} else {
-				pathsSeen.put(newFileName, 1);
+				pathsSeen.put(newFileName, 0);
 			}
 
 			if (f.isDirectory()) {
-				if(pathsSeen.get(newFileName) == 1) {
-					addDirToArchive(stream, f, newFileName);
-				} else {
-					addDirToArchive(stream, f, newFileName + "_" + pathsSeen.get(newFileName));
-				}
+				addDirToArchive(stream, f, newFileName + "_" + pathsSeen.get(newFileName));
 			} else {
-				if(pathsSeen.get(newFileName) == 1) {
-					addFileToArchive(stream, f, newFileName);
-				} else {
-					addFileToArchive(stream, f, newFileName + "_" +  pathsSeen.get(newFileName));
-				}
+				addFileToArchive(stream, f, newFileName + "_" +  pathsSeen.get(newFileName));
 			}
 		}
 		stream.finish();


### PR DESCRIPTION
A response to issue #260.

Processors were being ignored based on old code designed to not duplicate processors on output to the archive. If their name is the same, even with different directories on our disk, they wouldn't be sent to the output ZIP. To fix this, we removed this check, and replaced it with a system to make sure file names are unique upon download, which avoids mixing up processor files. This change affects ALL downloads, though the only changes are to the folder names upon downloading.