### PR TITLE
Escape commas in tool results

### DIFF
--- a/src/org/starexec/servlets/Download.java
+++ b/src/org/starexec/servlets/Download.java
@@ -444,7 +444,12 @@ public class Download extends HttpServlet {
 
 				sb.append(stage.getMaxVirtualMemory());
 				sb.append(",");
-				sb.append(stage.getStarexecResult());
+				// escape commas
+				if (stage.getStarExecResult().contains(",")) { 
+					sb.append("\""+stage.getStarexecResult().replaceAll("\"","\"\"")+"\"");
+				} else {
+					sb.append(stage.getStarExecResult());
+				}
 
 				if (attrNames != null) {
 					// print out attributes for this job pair


### PR DESCRIPTION
Currently commas are not escaped in the "result" column of the job information csv. 
For instance if a tool result is "WORST_CASE(O(n^1),O(n^1))" (this is the format required by the termination competition), then this result is not enclosed by quotes. 
Hence, the remaining string "O(n^1)" is not contained in the result field anymore.

Please note that I was **not** able to test this PR since I do not have the required dependencies installed.