### PR TITLE
Fix 307

### DIFF
--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -11,8 +11,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.guest_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.guest_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -26,13 +31,23 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.temp_005fpass_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.temp_005fpass_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.temp_005fpass_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.temp_005fpass_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.guest_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.guest_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -46,18 +61,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.registration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.registration_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -66,18 +71,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.configuration_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.login_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -86,8 +81,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.login_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.configuration_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.registration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.registration_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -106,6 +106,11 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.space_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.add.jobPairs_jsp</servlet-class>
     </servlet>
@@ -121,23 +126,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.space_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.add.benchmarks_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.quickJob_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -146,18 +136,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.status_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.quickJob_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -171,13 +151,33 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.stressTest_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.cluster_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.status_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.user_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.stressTest_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -191,6 +191,11 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.cluster_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.admin.analytics_jsp</servlet-class>
     </servlet>
@@ -201,13 +206,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.user_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -216,8 +216,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -226,13 +226,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -241,8 +241,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -256,33 +256,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.pair_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -291,8 +266,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.solverComparison_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -301,8 +286,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.statistics_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -311,8 +296,28 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.solverComparison_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.user_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.pair_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.explore.communities_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.statistics_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -321,8 +326,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.solver_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.reports_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -336,28 +341,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.reports_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.explore.spaces_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.user_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.benchmark_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.solver_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -366,8 +356,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -376,8 +366,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.solver_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.benchmark_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.solver_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.community_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -391,8 +391,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.community_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -416,8 +416,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.guest_jsp</servlet-name>
-        <url-pattern>/public/guest.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <url-pattern>/public/messages/error.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
+        <url-pattern>/public/messages/email_changed.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -431,13 +436,23 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
-        <url-pattern>/public/messages/email_changed.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.temp_005fpass_jsp</servlet-name>
+        <url-pattern>/public/temp_pass.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.temp_005fpass_jsp</servlet-name>
-        <url-pattern>/public/temp_pass.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.guest_jsp</servlet-name>
+        <url-pattern>/public/guest.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <url-pattern>/public/help.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <url-pattern>/public/jobs/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -451,18 +466,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <url-pattern>/public/help.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.registration_jsp</servlet-name>
-        <url-pattern>/public/registration.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <url-pattern>/public/messages/error.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
+        <url-pattern>/public/registrationConfirmation.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -471,18 +476,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <url-pattern>/public/jobs/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
-        <url-pattern>/public/registrationConfirmation.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
-        <url-pattern>/secure/add/configuration.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
+        <url-pattern>/public/login.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -491,8 +486,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
-        <url-pattern>/public/login.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
+        <url-pattern>/secure/add/configuration.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.registration_jsp</servlet-name>
+        <url-pattern>/public/registration.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -511,6 +511,11 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
+        <url-pattern>/secure/add/space.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
         <url-pattern>/secure/add/jobPairs.jsp</url-pattern>
     </servlet-mapping>
@@ -526,23 +531,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
-        <url-pattern>/secure/add/space.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
         <url-pattern>/secure/add/benchmarks.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
-        <url-pattern>/secure/add/quickJob.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -551,18 +541,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <url-pattern>/secure/admin/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
-        <url-pattern>/secure/admin/status.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <url-pattern>/secure/admin/queue.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
+        <url-pattern>/secure/add/quickJob.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -576,13 +556,33 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
-        <url-pattern>/secure/admin/stressTest.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <url-pattern>/secure/admin/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
-        <url-pattern>/secure/admin/cluster.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <url-pattern>/secure/admin/queue.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
+        <url-pattern>/secure/admin/status.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
+        <url-pattern>/secure/admin/user.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
+        <url-pattern>/secure/admin/stressTest.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -596,6 +596,11 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
+        <url-pattern>/secure/admin/cluster.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
         <url-pattern>/secure/admin/analytics.jsp</url-pattern>
     </servlet-mapping>
@@ -606,13 +611,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
-        <url-pattern>/secure/admin/user.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
-        <url-pattern>/secure/admin/moveNodes.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
+        <url-pattern>/secure/admin/community.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -621,8 +621,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
-        <url-pattern>/secure/admin/community.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
+        <url-pattern>/secure/admin/moveNodes.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -631,13 +631,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-name>
-        <url-pattern>/secure/admin/assocCommunity.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
+        <url-pattern>/secure/details/anonymousJobPageKey.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
-        <url-pattern>/secure/details/anonymousJobPageKey.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-name>
+        <url-pattern>/secure/admin/assocCommunity.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -646,8 +646,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
-        <url-pattern>/secure/details/pairsInSpace.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
+        <url-pattern>/secure/details/conflictingSolvers.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -661,33 +661,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
-        <url-pattern>/secure/details/conflictingSolvers.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
-        <url-pattern>/secure/details/jobAttributes.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
-        <url-pattern>/secure/details/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-name>
-        <url-pattern>/secure/details/solverconfigs.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
-        <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
-        <url-pattern>/secure/details/pair.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
+        <url-pattern>/secure/details/pairsInSpace.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -696,8 +671,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
-        <url-pattern>/secure/details/solverComparison.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
+        <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-name>
+        <url-pattern>/secure/details/solverconfigs.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
+        <url-pattern>/secure/details/jobAttributes.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -706,8 +691,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
-        <url-pattern>/secure/explore/statistics.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
+        <url-pattern>/secure/details/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -716,8 +701,28 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
+        <url-pattern>/secure/details/solverComparison.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
+        <url-pattern>/secure/details/user.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
+        <url-pattern>/secure/details/pair.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
         <url-pattern>/secure/explore/communities.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
+        <url-pattern>/secure/explore/statistics.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -726,8 +731,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
-        <url-pattern>/secure/details/solver.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
+        <url-pattern>/secure/explore/reports.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -741,28 +746,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
-        <url-pattern>/secure/explore/reports.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
         <url-pattern>/secure/explore/spaces.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
-        <url-pattern>/secure/details/user.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
-        <url-pattern>/secure/edit/resubmitPairs.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
-        <url-pattern>/secure/details/benchmark.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
+        <url-pattern>/secure/edit/solver.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -771,8 +761,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <url-pattern>/secure/edit/processor.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
+        <url-pattern>/secure/edit/resubmitPairs.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -781,8 +771,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
-        <url-pattern>/secure/edit/solver.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
+        <url-pattern>/secure/details/benchmark.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
+        <url-pattern>/secure/details/solver.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
+        <url-pattern>/secure/edit/community.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -796,8 +796,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
-        <url-pattern>/secure/edit/community.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <url-pattern>/secure/edit/processor.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -11,13 +11,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.guest_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.guest_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -31,23 +26,13 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.public_.temp_005fpass_jsp</servlet-name>
         <servlet-class>org.apache.jsp.public_.temp_005fpass_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.guest_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.guest_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -61,8 +46,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.registration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.registration_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -71,13 +66,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.login_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.batchSpace_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -86,8 +81,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.registration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.registration_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.batchSpace_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.login_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -106,11 +106,6 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.space_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.add.jobPairs_jsp</servlet-class>
     </servlet>
@@ -126,8 +121,23 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.space_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.add.benchmarks_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.quickJob_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -136,8 +146,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.quickJob_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.status_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -151,33 +171,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.status_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.user_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.admin.stressTest_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.cluster_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -191,11 +191,6 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.cluster_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.admin.analytics_jsp</servlet-class>
     </servlet>
@@ -206,13 +201,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.starexec_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.user_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -221,13 +211,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.starexec_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -236,13 +231,18 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.details.configDeleted_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.configDeleted_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -256,23 +256,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -281,28 +266,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.solverComparison_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.user_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -311,8 +286,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.communities_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.solverComparison_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -321,13 +306,23 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.communities_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.explore.cluster_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.reports_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.solver_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -341,18 +336,18 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.reports_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.explore.spaces_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.solver_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.benchmark_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.user_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -361,23 +356,28 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.benchmark_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.solver_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.benchmark_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.community_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.solver_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -391,8 +391,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.community_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -416,13 +416,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <url-pattern>/public/messages/error.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
-        <url-pattern>/public/messages/email_changed.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.guest_jsp</servlet-name>
+        <url-pattern>/public/guest.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -436,23 +431,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
+        <url-pattern>/public/messages/email_changed.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.public_.temp_005fpass_jsp</servlet-name>
         <url-pattern>/public/temp_pass.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.guest_jsp</servlet-name>
-        <url-pattern>/public/guest.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <url-pattern>/public/help.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <url-pattern>/public/jobs/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -466,8 +451,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
-        <url-pattern>/public/registrationConfirmation.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <url-pattern>/public/help.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.registration_jsp</servlet-name>
+        <url-pattern>/public/registration.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <url-pattern>/public/messages/error.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -476,13 +471,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
-        <url-pattern>/public/login.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <url-pattern>/public/jobs/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
-        <url-pattern>/secure/add/batchSpace.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
+        <url-pattern>/public/registrationConfirmation.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -491,8 +486,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.registration_jsp</servlet-name>
-        <url-pattern>/public/registration.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
+        <url-pattern>/secure/add/batchSpace.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
+        <url-pattern>/public/login.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -511,11 +511,6 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
-        <url-pattern>/secure/add/space.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
         <url-pattern>/secure/add/jobPairs.jsp</url-pattern>
     </servlet-mapping>
@@ -531,8 +526,23 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
+        <url-pattern>/secure/add/space.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
         <url-pattern>/secure/add/benchmarks.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
+        <url-pattern>/secure/add/quickJob.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -541,8 +551,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
-        <url-pattern>/secure/add/quickJob.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <url-pattern>/secure/admin/job.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
+        <url-pattern>/secure/admin/status.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <url-pattern>/secure/admin/queue.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -556,33 +576,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <url-pattern>/secure/admin/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <url-pattern>/secure/admin/queue.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
-        <url-pattern>/secure/admin/status.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
-        <url-pattern>/secure/admin/user.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
         <url-pattern>/secure/admin/stressTest.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
+        <url-pattern>/secure/admin/cluster.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -596,11 +596,6 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
-        <url-pattern>/secure/admin/cluster.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
         <url-pattern>/secure/admin/analytics.jsp</url-pattern>
     </servlet-mapping>
@@ -611,13 +606,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
-        <url-pattern>/secure/admin/community.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
-        <url-pattern>/secure/admin/starexec.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
+        <url-pattern>/secure/admin/user.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -626,13 +616,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-name>
-        <url-pattern>/secure/details/XMLuploadStatus.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
+        <url-pattern>/secure/admin/starexec.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
-        <url-pattern>/secure/details/anonymousJobPageKey.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
+        <url-pattern>/secure/admin/community.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-name>
+        <url-pattern>/secure/details/XMLuploadStatus.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -641,13 +636,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
+        <url-pattern>/secure/details/anonymousJobPageKey.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.configDeleted_jsp</servlet-name>
         <url-pattern>/secure/details/configDeleted.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
-        <url-pattern>/secure/details/conflictingSolvers.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
+        <url-pattern>/secure/details/pairsInSpace.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -661,23 +661,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
-        <url-pattern>/secure/details/pairsInSpace.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
-        <url-pattern>/secure/details/jobPanelView.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
-        <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-name>
-        <url-pattern>/secure/details/solverconfigs.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
+        <url-pattern>/secure/details/conflictingSolvers.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -686,28 +671,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-name>
-        <url-pattern>/secure/details/conflictingBenchmarks.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
         <url-pattern>/secure/details/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
-        <url-pattern>/secure/details/uploadStatus.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.solverconfigs_jsp</servlet-name>
+        <url-pattern>/secure/details/solverconfigs.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
-        <url-pattern>/secure/details/solverComparison.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
-        <url-pattern>/secure/details/user.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
+        <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -716,8 +691,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
-        <url-pattern>/secure/explore/communities.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
+        <url-pattern>/secure/details/jobPanelView.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
+        <url-pattern>/secure/details/solverComparison.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-name>
+        <url-pattern>/secure/details/conflictingBenchmarks.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -726,13 +711,23 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
+        <url-pattern>/secure/details/uploadStatus.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
+        <url-pattern>/secure/explore/communities.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
         <url-pattern>/secure/explore/cluster.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
-        <url-pattern>/secure/explore/reports.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
+        <url-pattern>/secure/details/solver.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -746,18 +741,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
+        <url-pattern>/secure/explore/reports.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
         <url-pattern>/secure/explore/spaces.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
-        <url-pattern>/secure/edit/solver.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
-        <url-pattern>/secure/edit/benchmark.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
+        <url-pattern>/secure/details/user.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -766,23 +761,28 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
-        <url-pattern>/secure/edit/processBenchmarks.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
         <url-pattern>/secure/details/benchmark.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
-        <url-pattern>/secure/details/solver.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
+        <url-pattern>/secure/edit/benchmark.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
-        <url-pattern>/secure/edit/community.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <url-pattern>/secure/edit/processor.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
+        <url-pattern>/secure/edit/processBenchmarks.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
+        <url-pattern>/secure/edit/solver.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -796,8 +796,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <url-pattern>/secure/edit/processor.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
+        <url-pattern>/secure/edit/community.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/src/org/starexec/data/database/Solvers.java
+++ b/src/org/starexec/data/database/Solvers.java
@@ -430,13 +430,24 @@ public class Solvers {
 		newSolver.setType(s.getType());
 		newSolver.setBuildStatus(s.buildStatus());
 		File solverDirectory = new File(s.getPath());
-
 		File uniqueDir = new File(R.getSolverPath(), "" + userId);
 		uniqueDir = new File(uniqueDir, newSolver.getName());
-		uniqueDir = new File(uniqueDir, "" + shortDate.format(new Date()));
+		String date = shortDate.format(new Date());
+		uniqueDir = new File(uniqueDir, "" + date);
 		uniqueDir.mkdirs();
 		newSolver.setPath(uniqueDir.getAbsolutePath());
 		try {
+			//we need to check if the solver has a src dir. If it does, we also need to 
+			//copy it. This fixes issue 307
+			File maybeSrc = new File(s.getPath()+ "_src");
+			boolean hasSrc = maybeSrc.exists();
+			if (hasSrc) {
+				File originalSrcDir = maybeSrc;
+				File newSrcDir = new File(uniqueDir.getAbsolutePath() + "_src");
+				newSrcDir.mkdirs();
+				FileUtils.copyDirectory(originalSrcDir, newSrcDir);
+			}
+			
 			FileUtils.copyDirectory(solverDirectory, uniqueDir);
 			for (Configuration c : findConfigs(uniqueDir.getAbsolutePath())) {
 				newSolver.addConfiguration(c);


### PR DESCRIPTION
Fixed corrupted src files.
The problem was that when solvers are copied from one space to another, the solver src never gets copied. This fixes that by making sure that the solver is copied. 