### PR TITLE
Fix queue chart

### DIFF
--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -16,13 +16,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.starexeccommand_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -36,8 +36,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.password_005freset_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.password_005freset_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.starexeccommand_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -46,8 +46,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.password_005freset_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.password_005freset_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -56,23 +61,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.quickReference_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.quickReference_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -81,8 +71,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.batchSpace_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.quickReference_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.quickReference_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -91,13 +81,38 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.batchSpace_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-class>
     </servlet>
 
     <servlet>
         <servlet-name>org.apache.jsp.secure.add.picture_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.add.picture_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.space_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.batchJob_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -111,53 +126,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.help_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.batchJob_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.space_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.add.benchmarks_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.quickJob_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.status_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.help_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -171,8 +146,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.stressTest_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -181,23 +166,18 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.quickJob_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.logging_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.logging_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.analytics_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.permissions_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.stressTest_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -206,8 +186,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.permissions_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.status_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -216,13 +201,18 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.add.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.job_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -231,8 +221,28 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.analytics_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.logging_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.logging_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -246,23 +256,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.configuration_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-class>
     </servlet>
 
     <servlet>
         <servlet-name>org.apache.jsp.secure.details.recycleBin_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.recycleBin_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -276,13 +276,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.configuration_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.pair_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -291,18 +291,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.solverComparison_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.statistics_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.solverComparison_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -311,13 +306,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.communities_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.cluster_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.user_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -326,18 +316,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.configuration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.configuration_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.pair_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.space_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.communities_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.reports_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.statistics_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -346,13 +336,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.user_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.reports_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.cluster_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.configuration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.configuration_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -361,23 +356,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.benchmark_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.solver_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.space_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -386,13 +371,33 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.solver_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.benchmark_jsp</servlet-class>
     </servlet>
 
     <servlet>
         <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.edit.community_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -421,13 +426,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
-        <url-pattern>/public/messages/leader_response.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <url-pattern>/public/messages/error.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
-        <url-pattern>/public/starexeccommand.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
+        <url-pattern>/public/messages/leader_response.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -441,8 +446,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.password_005freset_jsp</servlet-name>
-        <url-pattern>/public/password_reset.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
+        <url-pattern>/public/starexeccommand.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -451,8 +456,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <url-pattern>/public/help.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
+        <url-pattern>/public/registrationConfirmation.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.password_005freset_jsp</servlet-name>
+        <url-pattern>/public/password_reset.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -461,23 +471,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <url-pattern>/public/messages/error.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.quickReference_jsp</servlet-name>
-        <url-pattern>/public/quickReference.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <url-pattern>/public/jobs/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
-        <url-pattern>/public/registrationConfirmation.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <url-pattern>/public/help.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -486,8 +481,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
-        <url-pattern>/secure/add/batchSpace.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.quickReference_jsp</servlet-name>
+        <url-pattern>/public/quickReference.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -496,13 +491,38 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-name>
-        <url-pattern>/secure/add/to_community.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <url-pattern>/public/jobs/job.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
+        <url-pattern>/secure/add/batchSpace.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-name>
+        <url-pattern>/secure/add/addJobLocked.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.add.picture_jsp</servlet-name>
         <url-pattern>/secure/add/picture.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-name>
+        <url-pattern>/secure/add/to_community.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
+        <url-pattern>/secure/add/space.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
+        <url-pattern>/secure/add/batchJob.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -516,53 +536,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
-        <url-pattern>/secure/help.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
-        <url-pattern>/secure/add/batchJob.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
-        <url-pattern>/secure/add/space.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
         <url-pattern>/secure/add/benchmarks.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
-        <url-pattern>/secure/add/quickJob.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.job_jsp</servlet-name>
-        <url-pattern>/secure/add/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <url-pattern>/secure/admin/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
-        <url-pattern>/secure/admin/status.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <url-pattern>/secure/admin/queue.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
+        <url-pattern>/secure/help.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -576,8 +556,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
-        <url-pattern>/secure/admin/stressTest.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <url-pattern>/secure/admin/job.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <url-pattern>/secure/admin/queue.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -586,23 +576,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
+        <url-pattern>/secure/add/quickJob.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-name>
         <url-pattern>/secure/admin/jobpairErrors.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.logging_jsp</servlet-name>
-        <url-pattern>/secure/admin/logging.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
-        <url-pattern>/secure/admin/analytics.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
-        <url-pattern>/secure/admin/permissions.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
+        <url-pattern>/secure/admin/stressTest.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -611,8 +596,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
-        <url-pattern>/secure/admin/moveNodes.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
+        <url-pattern>/secure/admin/permissions.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
+        <url-pattern>/secure/admin/status.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -621,13 +611,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.job_jsp</servlet-name>
+        <url-pattern>/secure/add/job.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
         <url-pattern>/secure/admin/community.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-name>
-        <url-pattern>/secure/details/XMLuploadStatus.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
+        <url-pattern>/secure/admin/moveNodes.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -636,8 +631,28 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
+        <url-pattern>/secure/admin/analytics.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
         <url-pattern>/secure/details/anonymousJobPageKey.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.logging_jsp</servlet-name>
+        <url-pattern>/secure/admin/logging.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-name>
+        <url-pattern>/secure/details/XMLuploadStatus.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
+        <url-pattern>/secure/details/conflictingSolvers.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -651,23 +666,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
-        <url-pattern>/secure/details/configuration.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
+        <url-pattern>/secure/details/jobAttributes.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.recycleBin_jsp</servlet-name>
         <url-pattern>/secure/details/recycleBin.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
-        <url-pattern>/secure/details/conflictingSolvers.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
-        <url-pattern>/secure/details/jobAttributes.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -681,13 +686,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
-        <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
+        <url-pattern>/secure/details/configuration.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
-        <url-pattern>/secure/details/pair.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
+        <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -696,18 +701,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
-        <url-pattern>/secure/details/solverComparison.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-name>
         <url-pattern>/secure/details/conflictingBenchmarks.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
-        <url-pattern>/secure/explore/statistics.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
+        <url-pattern>/secure/details/solverComparison.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -716,13 +716,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
-        <url-pattern>/secure/explore/communities.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
-        <url-pattern>/secure/explore/cluster.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
+        <url-pattern>/secure/details/user.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -731,18 +726,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.configuration_jsp</servlet-name>
-        <url-pattern>/secure/edit/configuration.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
+        <url-pattern>/secure/details/pair.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
-        <url-pattern>/secure/edit/space.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
+        <url-pattern>/secure/explore/communities.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
-        <url-pattern>/secure/explore/reports.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
+        <url-pattern>/secure/explore/statistics.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -751,13 +746,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
-        <url-pattern>/secure/details/user.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
+        <url-pattern>/secure/explore/reports.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
-        <url-pattern>/secure/edit/resubmitPairs.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
+        <url-pattern>/secure/explore/cluster.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.configuration_jsp</servlet-name>
+        <url-pattern>/secure/edit/configuration.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -766,23 +766,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
-        <url-pattern>/secure/edit/benchmark.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
+        <url-pattern>/secure/edit/resubmitPairs.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <url-pattern>/secure/edit/processor.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
-        <url-pattern>/secure/edit/processBenchmarks.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
-        <url-pattern>/secure/edit/solver.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
+        <url-pattern>/secure/edit/space.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -791,13 +781,33 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-name>
-        <url-pattern>/secure/edit/defaultPrimitive.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
+        <url-pattern>/secure/edit/solver.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
+        <url-pattern>/secure/edit/benchmark.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
         <url-pattern>/secure/edit/community.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <url-pattern>/secure/edit/processor.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-name>
+        <url-pattern>/secure/edit/defaultPrimitive.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
+        <url-pattern>/secure/edit/processBenchmarks.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -16,18 +16,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.starexeccommand_jsp</servlet-class>
     </servlet>
 
     <servlet>
         <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
         <servlet-class>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -41,18 +41,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.starexeccommand_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.public_.about_jsp</servlet-name>
         <servlet-class>org.apache.jsp.public_.about_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -61,18 +56,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.configuration_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.login_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -81,8 +66,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.picture_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.picture_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.configuration_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -91,8 +86,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.login_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -101,18 +96,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.space_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.jobPairs_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.add.picture_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.picture_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -121,13 +106,33 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.benchmarks_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.jobPairs_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.help_jsp</servlet-class>
     </servlet>
 
     <servlet>
         <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.add.batchJob_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.space_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.benchmarks_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -141,13 +146,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.testing_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.testing_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -156,33 +156,18 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.admin.testResults_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.admin.testResults_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.help_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.cluster_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.testing_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.testing_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -191,13 +176,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.analytics_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.cluster_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.starexec_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -206,8 +191,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.analytics_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.permissions_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -216,8 +206,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.permissions_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.starexec_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -231,11 +231,6 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-class>
     </servlet>
@@ -243,6 +238,16 @@
     <servlet>
         <servlet-name>org.apache.jsp.secure.details.configDeleted_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.configDeleted_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.configuration_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -261,13 +266,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -276,23 +276,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.configuration_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.job_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
     </servlet>
 
     <servlet>
         <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.pair_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -306,18 +301,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.solver_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.explore.statistics_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -326,23 +316,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.reports_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.explore.cluster_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.space_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.user_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.solver_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -351,18 +331,23 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.space_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.reports_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.explore.spaces_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.solver_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.benchmark_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.user_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -371,8 +356,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.benchmark_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -381,13 +366,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.solver_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -396,18 +386,23 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.edit.community_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.index_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.index_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.queue_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.queue_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.queue_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.queue_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.index_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.index_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -426,18 +421,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <url-pattern>/public/messages/error.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
+        <url-pattern>/public/messages/leader_response.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
+        <url-pattern>/public/starexeccommand.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
         <url-pattern>/public/messages/email_changed.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
-        <url-pattern>/public/messages/leader_response.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -451,18 +446,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <url-pattern>/public/help.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
-        <url-pattern>/public/starexeccommand.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.public_.about_jsp</servlet-name>
         <url-pattern>/public/about.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <url-pattern>/public/help.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -471,18 +461,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
-        <url-pattern>/secure/add/configuration.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
-        <url-pattern>/public/registrationConfirmation.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
-        <url-pattern>/public/login.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <url-pattern>/public/messages/error.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -491,8 +471,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.picture_jsp</servlet-name>
-        <url-pattern>/secure/add/picture.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <url-pattern>/public/jobs/job.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
+        <url-pattern>/public/registrationConfirmation.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
+        <url-pattern>/secure/add/configuration.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -501,8 +491,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <url-pattern>/public/jobs/job.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
+        <url-pattern>/public/login.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -511,18 +501,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
-        <url-pattern>/secure/add/space.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
-        <url-pattern>/secure/add/jobPairs.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-name>
-        <url-pattern>/secure/add/addJobLocked.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.add.picture_jsp</servlet-name>
+        <url-pattern>/secure/add/picture.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -531,13 +511,33 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
-        <url-pattern>/secure/add/benchmarks.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
+        <url-pattern>/secure/add/jobPairs.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
+        <url-pattern>/secure/help.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
         <url-pattern>/secure/add/batchJob.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
+        <url-pattern>/secure/add/space.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
+        <url-pattern>/secure/add/benchmarks.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -551,13 +551,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.testing_jsp</servlet-name>
-        <url-pattern>/secure/admin/testing.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <url-pattern>/secure/admin/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -566,33 +561,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <url-pattern>/secure/admin/queue.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.admin.testResults_jsp</servlet-name>
         <url-pattern>/secure/admin/testResults.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
-        <url-pattern>/secure/help.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-name>
-        <url-pattern>/secure/admin/jobpairErrors.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <url-pattern>/secure/admin/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
-        <url-pattern>/secure/admin/cluster.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <url-pattern>/secure/admin/queue.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.testing_jsp</servlet-name>
+        <url-pattern>/secure/admin/testing.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -601,13 +581,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
-        <url-pattern>/secure/admin/analytics.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
+        <url-pattern>/secure/admin/cluster.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
-        <url-pattern>/secure/admin/starexec.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-name>
+        <url-pattern>/secure/admin/jobpairErrors.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -616,8 +596,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
-        <url-pattern>/secure/admin/community.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
+        <url-pattern>/secure/admin/analytics.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
+        <url-pattern>/secure/admin/permissions.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -626,8 +611,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
-        <url-pattern>/secure/admin/permissions.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
+        <url-pattern>/secure/admin/moveNodes.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
+        <url-pattern>/secure/admin/starexec.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
+        <url-pattern>/secure/admin/community.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -641,11 +636,6 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
-        <url-pattern>/secure/admin/moveNodes.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
         <url-pattern>/secure/details/anonymousJobPageKey.jsp</url-pattern>
     </servlet-mapping>
@@ -653,6 +643,16 @@
     <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.configDeleted_jsp</servlet-name>
         <url-pattern>/secure/details/configDeleted.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
+        <url-pattern>/secure/details/pairsInSpace.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
+        <url-pattern>/secure/details/configuration.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -671,13 +671,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
-        <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
-        <url-pattern>/secure/details/pairsInSpace.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
+        <url-pattern>/secure/details/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -686,23 +681,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
-        <url-pattern>/secure/details/jobPanelView.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
-        <url-pattern>/secure/details/configuration.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
-        <url-pattern>/secure/details/job.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
+        <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
         <url-pattern>/secure/details/pair.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
+        <url-pattern>/secure/details/jobPanelView.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -716,18 +706,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
-        <url-pattern>/secure/details/uploadStatus.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
-        <url-pattern>/secure/details/solver.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
         <url-pattern>/secure/explore/statistics.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
+        <url-pattern>/secure/details/uploadStatus.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -736,23 +721,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
-        <url-pattern>/secure/explore/reports.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
         <url-pattern>/secure/explore/cluster.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
-        <url-pattern>/secure/edit/space.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
-        <url-pattern>/secure/details/user.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
+        <url-pattern>/secure/details/solver.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -761,18 +736,23 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
+        <url-pattern>/secure/edit/space.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
+        <url-pattern>/secure/explore/reports.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
         <url-pattern>/secure/explore/spaces.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
-        <url-pattern>/secure/edit/solver.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
-        <url-pattern>/secure/details/benchmark.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
+        <url-pattern>/secure/details/user.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -781,8 +761,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
-        <url-pattern>/secure/edit/processBenchmarks.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
+        <url-pattern>/secure/details/benchmark.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -791,13 +771,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-name>
-        <url-pattern>/secure/edit/defaultPrimitive.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <url-pattern>/secure/edit/processor.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <url-pattern>/secure/edit/processor.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
+        <url-pattern>/secure/edit/processBenchmarks.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
+        <url-pattern>/secure/edit/solver.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -806,18 +791,23 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.defaultPrimitive_jsp</servlet-name>
+        <url-pattern>/secure/edit/defaultPrimitive.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
         <url-pattern>/secure/edit/community.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.index_jsp</servlet-name>
-        <url-pattern>/secure/index.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.queue_jsp</servlet-name>
+        <url-pattern>/secure/edit/queue.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.queue_jsp</servlet-name>
-        <url-pattern>/secure/edit/queue.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.index_jsp</servlet-name>
+        <url-pattern>/secure/index.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -16,13 +16,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.starexeccommand_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -36,8 +36,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.starexeccommand_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.password_005freset_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.password_005freset_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -46,13 +46,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.password_005freset_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.password_005freset_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -61,13 +56,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.configuration_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -76,13 +66,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.login_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.configuration_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -91,13 +86,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.picture_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.picture_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.login_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -106,13 +96,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.space_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.batchJob_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.add.picture_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.picture_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -126,13 +111,53 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.help_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.batchJob_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.space_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.add.benchmarks_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.help_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.quickJob_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.job_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.status_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -146,18 +171,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.stressTest_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -166,68 +181,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.quickJob_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.stressTest_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.user_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.permissions_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.status_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.starexec_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.analytics_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -236,13 +191,48 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.analytics_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.permissions_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.user_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.starexec_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -256,13 +246,23 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.configuration_jsp</servlet-class>
     </servlet>
 
     <servlet>
         <servlet-name>org.apache.jsp.secure.details.recycleBin_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.recycleBin_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -276,43 +276,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.configuration_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.solverComparison_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.user_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.solver_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -321,8 +286,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.communities_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.solverComparison_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -331,13 +306,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.spaces_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.reports_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.communities_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -346,18 +321,13 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.solver_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.edit.configuration_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.edit.configuration_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.benchmark_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -366,13 +336,28 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.reports_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.solver_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.spaces_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.user_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.benchmark_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -381,13 +366,23 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.community_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.solver_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -396,8 +391,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.community_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -426,13 +421,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <url-pattern>/public/messages/error.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
+        <url-pattern>/public/messages/leader_response.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
-        <url-pattern>/public/messages/leader_response.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
+        <url-pattern>/public/starexeccommand.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -446,8 +441,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
-        <url-pattern>/public/starexeccommand.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.password_005freset_jsp</servlet-name>
+        <url-pattern>/public/password_reset.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -456,13 +451,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
-        <url-pattern>/public/registrationConfirmation.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.password_005freset_jsp</servlet-name>
-        <url-pattern>/public/password_reset.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <url-pattern>/public/help.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -471,13 +461,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <url-pattern>/public/help.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
-        <url-pattern>/secure/add/configuration.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <url-pattern>/public/messages/error.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -486,13 +471,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
-        <url-pattern>/public/login.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <url-pattern>/public/jobs/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <url-pattern>/public/jobs/job.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.registrationConfirmation_jsp</servlet-name>
+        <url-pattern>/public/registrationConfirmation.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
+        <url-pattern>/secure/add/configuration.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -501,13 +491,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-name>
-        <url-pattern>/secure/add/addJobLocked.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.picture_jsp</servlet-name>
-        <url-pattern>/secure/add/picture.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
+        <url-pattern>/public/login.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -516,13 +501,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
-        <url-pattern>/secure/add/space.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
-        <url-pattern>/secure/add/batchJob.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.add.picture_jsp</servlet-name>
+        <url-pattern>/secure/add/picture.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -536,13 +516,53 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
+        <url-pattern>/secure/help.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
+        <url-pattern>/secure/add/batchJob.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.space_jsp</servlet-name>
+        <url-pattern>/secure/add/space.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
         <url-pattern>/secure/add/benchmarks.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
-        <url-pattern>/secure/help.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
+        <url-pattern>/secure/add/quickJob.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.job_jsp</servlet-name>
+        <url-pattern>/secure/add/job.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <url-pattern>/secure/admin/job.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
+        <url-pattern>/secure/admin/status.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <url-pattern>/secure/admin/queue.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -556,18 +576,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <url-pattern>/secure/admin/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <url-pattern>/secure/admin/queue.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
+        <url-pattern>/secure/admin/stressTest.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -576,68 +586,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.quickJob_jsp</servlet-name>
-        <url-pattern>/secure/add/quickJob.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.admin.jobpairErrors_jsp</servlet-name>
         <url-pattern>/secure/admin/jobpairErrors.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
-        <url-pattern>/secure/admin/stressTest.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
-        <url-pattern>/secure/admin/user.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
-        <url-pattern>/secure/admin/permissions.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
-        <url-pattern>/secure/admin/status.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
-        <url-pattern>/secure/admin/starexec.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.job_jsp</servlet-name>
-        <url-pattern>/secure/add/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
-        <url-pattern>/secure/admin/community.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
-        <url-pattern>/secure/admin/moveNodes.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-name>
-        <url-pattern>/secure/admin/assocCommunity.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
-        <url-pattern>/secure/admin/analytics.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
-        <url-pattern>/secure/details/anonymousJobPageKey.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -646,13 +596,48 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.analytics_jsp</servlet-name>
+        <url-pattern>/secure/admin/analytics.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
+        <url-pattern>/secure/admin/permissions.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.user_jsp</servlet-name>
+        <url-pattern>/secure/admin/user.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
+        <url-pattern>/secure/admin/moveNodes.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
+        <url-pattern>/secure/admin/starexec.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
+        <url-pattern>/secure/admin/community.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.XMLuploadStatus_jsp</servlet-name>
         <url-pattern>/secure/details/XMLuploadStatus.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
-        <url-pattern>/secure/details/conflictingSolvers.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.assocCommunity_jsp</servlet-name>
+        <url-pattern>/secure/admin/assocCommunity.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
+        <url-pattern>/secure/details/anonymousJobPageKey.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -666,13 +651,23 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
-        <url-pattern>/secure/details/jobAttributes.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
+        <url-pattern>/secure/details/configuration.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.recycleBin_jsp</servlet-name>
         <url-pattern>/secure/details/recycleBin.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.conflictingSolvers_jsp</servlet-name>
+        <url-pattern>/secure/details/conflictingSolvers.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.jobAttributes_jsp</servlet-name>
+        <url-pattern>/secure/details/jobAttributes.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -686,43 +681,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
-        <url-pattern>/secure/details/configuration.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
         <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
-        <url-pattern>/secure/details/jobPanelView.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-name>
-        <url-pattern>/secure/details/conflictingBenchmarks.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
-        <url-pattern>/secure/details/solverComparison.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
-        <url-pattern>/secure/details/uploadStatus.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
-        <url-pattern>/secure/details/user.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
-        <url-pattern>/secure/details/solver.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -731,8 +691,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
-        <url-pattern>/secure/explore/communities.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
+        <url-pattern>/secure/details/jobPanelView.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.solverComparison_jsp</servlet-name>
+        <url-pattern>/secure/details/solverComparison.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.conflictingBenchmarks_jsp</servlet-name>
+        <url-pattern>/secure/details/conflictingBenchmarks.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -741,13 +711,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
-        <url-pattern>/secure/explore/spaces.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
+        <url-pattern>/secure/details/uploadStatus.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
-        <url-pattern>/secure/explore/reports.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
+        <url-pattern>/secure/explore/communities.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -756,18 +726,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.solver_jsp</servlet-name>
+        <url-pattern>/secure/details/solver.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.edit.configuration_jsp</servlet-name>
         <url-pattern>/secure/edit/configuration.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
-        <url-pattern>/secure/details/benchmark.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
-        <url-pattern>/secure/edit/resubmitPairs.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -776,13 +741,28 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-name>
-        <url-pattern>/secure/edit/spacePermissions.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.reports_jsp</servlet-name>
+        <url-pattern>/secure/explore/reports.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
-        <url-pattern>/secure/edit/solver.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
+        <url-pattern>/secure/explore/spaces.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.user_jsp</servlet-name>
+        <url-pattern>/secure/details/user.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
+        <url-pattern>/secure/edit/resubmitPairs.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
+        <url-pattern>/secure/details/benchmark.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -791,13 +771,23 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
-        <url-pattern>/secure/edit/community.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <url-pattern>/secure/edit/processor.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <url-pattern>/secure/edit/processor.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
+        <url-pattern>/secure/edit/processBenchmarks.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.solver_jsp</servlet-name>
+        <url-pattern>/secure/edit/solver.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-name>
+        <url-pattern>/secure/edit/spacePermissions.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -806,8 +796,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
-        <url-pattern>/secure/edit/processBenchmarks.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
+        <url-pattern>/secure/edit/community.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -16,18 +16,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.starexeccommand_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
     </servlet>
 
     <servlet>
         <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
         <servlet-class>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -41,13 +41,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.about_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.about_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.help_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.starexeccommand_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.public_.about_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.about_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -56,18 +61,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.messages.error_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.quickReference_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.quickReference_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.configuration_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -76,23 +71,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.configuration_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.batchSpace_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
         <servlet-class>org.apache.jsp.public_.login_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.quickReference_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.quickReference_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -101,23 +86,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.solver_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.solver_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.batchSpace_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.jobPairs_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.public_.jobs.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.help_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.add.batchJob_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -126,13 +106,28 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.jobPairs_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.add.solver_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.solver_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.add.benchmarks_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.add.batchJob_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -146,23 +141,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.status_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.testResults_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.testResults_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.addUser_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -171,13 +151,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.stressTest_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.status_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.cluster_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.testResults_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.testResults_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.help_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -186,8 +171,23 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.logging_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.logging_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.job_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.cluster_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.queue_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.stressTest_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -196,8 +196,18 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.permissions_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.starexec_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.logging_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.logging_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -206,18 +216,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.starexec_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.admin.community_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.permissions_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -231,6 +231,11 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-class>
     </servlet>
@@ -238,16 +243,6 @@
     <servlet>
         <servlet-name>org.apache.jsp.secure.details.configDeleted_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.configDeleted_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.configuration_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -266,8 +261,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.job_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -276,18 +276,23 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.configuration_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.job_jsp</servlet-class>
     </servlet>
 
     <servlet>
         <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.pair_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -301,23 +306,8 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.statistics_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
         <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.communities_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.cluster_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -326,13 +316,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.configuration_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.configuration_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.statistics_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.space_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.communities_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -341,8 +331,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.explore.spaces_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.cluster_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.space_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -351,28 +346,13 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.configuration_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.configuration_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.details.benchmark_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.benchmark_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.explore.spaces_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -381,8 +361,23 @@
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.details.benchmark_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.benchmark_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -391,18 +386,28 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.processor_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-class>
+    </servlet>
+
+    <servlet>
         <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
         <servlet-class>org.apache.jsp.secure.edit.community_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.edit.queue_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.edit.queue_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.index_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.index_jsp</servlet-class>
     </servlet>
 
     <servlet>
-        <servlet-name>org.apache.jsp.secure.index_jsp</servlet-name>
-        <servlet-class>org.apache.jsp.secure.index_jsp</servlet-class>
+        <servlet-name>org.apache.jsp.secure.edit.queue_jsp</servlet-name>
+        <servlet-class>org.apache.jsp.secure.edit.queue_jsp</servlet-class>
     </servlet>
 
     <servlet>
@@ -421,18 +426,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
-        <url-pattern>/public/messages/leader_response.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
-        <url-pattern>/public/starexeccommand.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
+        <url-pattern>/public/messages/error.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>org.apache.jsp.public_.messages.email_005fchanged_jsp</servlet-name>
         <url-pattern>/public/messages/email_changed.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.messages.leader_005fresponse_jsp</servlet-name>
+        <url-pattern>/public/messages/leader_response.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -446,13 +451,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.about_jsp</servlet-name>
-        <url-pattern>/public/about.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
+        <url-pattern>/public/help.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.help_jsp</servlet-name>
-        <url-pattern>/public/help.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.starexeccommand_jsp</servlet-name>
+        <url-pattern>/public/starexeccommand.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.public_.about_jsp</servlet-name>
+        <url-pattern>/public/about.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -461,18 +471,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.messages.error_jsp</servlet-name>
-        <url-pattern>/public/messages/error.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.quickReference_jsp</servlet-name>
-        <url-pattern>/public/quickReference.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
-        <url-pattern>/public/jobs/job.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
+        <url-pattern>/secure/add/configuration.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -481,23 +481,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.configuration_jsp</servlet-name>
-        <url-pattern>/secure/add/configuration.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
-        <url-pattern>/secure/add/batchSpace.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.public_.login_jsp</servlet-name>
         <url-pattern>/public/login.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-name>
-        <url-pattern>/secure/add/to_community.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.quickReference_jsp</servlet-name>
+        <url-pattern>/public/quickReference.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -506,23 +496,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.solver_jsp</servlet-name>
-        <url-pattern>/secure/add/solver.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.add.batchSpace_jsp</servlet-name>
+        <url-pattern>/secure/add/batchSpace.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
-        <url-pattern>/secure/add/jobPairs.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.public_.jobs.job_jsp</servlet-name>
+        <url-pattern>/public/jobs/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
-        <url-pattern>/secure/help.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
-        <url-pattern>/secure/add/batchJob.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.add.to_005fcommunity_jsp</servlet-name>
+        <url-pattern>/secure/add/to_community.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -531,13 +516,28 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.jobPairs_jsp</servlet-name>
+        <url-pattern>/secure/add/jobPairs.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.addJobLocked_jsp</servlet-name>
+        <url-pattern>/secure/add/addJobLocked.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.add.solver_jsp</servlet-name>
+        <url-pattern>/secure/add/solver.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.add.benchmarks_jsp</servlet-name>
         <url-pattern>/secure/add/benchmarks.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
-        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.add.batchJob_jsp</servlet-name>
+        <url-pattern>/secure/add/batchJob.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -551,23 +551,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
-        <url-pattern>/secure/admin/job.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
-        <url-pattern>/secure/admin/status.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
-        <url-pattern>/secure/admin/queue.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.testResults_jsp</servlet-name>
-        <url-pattern>/secure/admin/testResults.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.addUser_jsp</servlet-name>
+        <url-pattern>/secure/admin/addUser.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -576,13 +561,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
-        <url-pattern>/secure/admin/stressTest.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.status_jsp</servlet-name>
+        <url-pattern>/secure/admin/status.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
-        <url-pattern>/secure/admin/cluster.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.testResults_jsp</servlet-name>
+        <url-pattern>/secure/admin/testResults.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.help_jsp</servlet-name>
+        <url-pattern>/secure/help.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -591,8 +581,23 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.logging_jsp</servlet-name>
-        <url-pattern>/secure/admin/logging.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.job_jsp</servlet-name>
+        <url-pattern>/secure/admin/job.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.cluster_jsp</servlet-name>
+        <url-pattern>/secure/admin/cluster.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.queue_jsp</servlet-name>
+        <url-pattern>/secure/admin/queue.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.stressTest_jsp</servlet-name>
+        <url-pattern>/secure/admin/stressTest.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -601,8 +606,18 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
-        <url-pattern>/secure/admin/permissions.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
+        <url-pattern>/secure/admin/starexec.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.logging_jsp</servlet-name>
+        <url-pattern>/secure/admin/logging.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
+        <url-pattern>/secure/admin/community.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -611,18 +626,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
-        <url-pattern>/secure/admin/moveNodes.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.starexec_jsp</servlet-name>
-        <url-pattern>/secure/admin/starexec.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.admin.community_jsp</servlet-name>
-        <url-pattern>/secure/admin/community.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.admin.permissions_jsp</servlet-name>
+        <url-pattern>/secure/admin/permissions.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -636,6 +641,11 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.admin.moveNodes_jsp</servlet-name>
+        <url-pattern>/secure/admin/moveNodes.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.anonymousJobPageKey_jsp</servlet-name>
         <url-pattern>/secure/details/anonymousJobPageKey.jsp</url-pattern>
     </servlet-mapping>
@@ -643,16 +653,6 @@
     <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.configDeleted_jsp</servlet-name>
         <url-pattern>/secure/details/configDeleted.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
-        <url-pattern>/secure/details/pairsInSpace.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
-        <url-pattern>/secure/details/configuration.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -671,8 +671,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
-        <url-pattern>/secure/details/job.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
+        <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.pairsInSpace_jsp</servlet-name>
+        <url-pattern>/secure/details/pairsInSpace.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -681,18 +686,23 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobMatrixView_jsp</servlet-name>
-        <url-pattern>/secure/details/jobMatrixView.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
+        <url-pattern>/secure/details/jobPanelView.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.configuration_jsp</servlet-name>
+        <url-pattern>/secure/details/configuration.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.details.job_jsp</servlet-name>
+        <url-pattern>/secure/details/job.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.pair_jsp</servlet-name>
         <url-pattern>/secure/details/pair.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.jobPanelView_jsp</servlet-name>
-        <url-pattern>/secure/details/jobPanelView.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -706,23 +716,8 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
-        <url-pattern>/secure/explore/statistics.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.details.uploadStatus_jsp</servlet-name>
         <url-pattern>/secure/details/uploadStatus.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
-        <url-pattern>/secure/explore/communities.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
-        <url-pattern>/secure/explore/cluster.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -731,13 +726,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.configuration_jsp</servlet-name>
-        <url-pattern>/secure/edit/configuration.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.statistics_jsp</servlet-name>
+        <url-pattern>/secure/explore/statistics.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
-        <url-pattern>/secure/edit/space.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.communities_jsp</servlet-name>
+        <url-pattern>/secure/explore/communities.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -746,8 +741,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
-        <url-pattern>/secure/explore/spaces.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.cluster_jsp</servlet-name>
+        <url-pattern>/secure/explore/cluster.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.space_jsp</servlet-name>
+        <url-pattern>/secure/edit/space.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -756,28 +756,13 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
-        <url-pattern>/secure/edit/resubmitPairs.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.configuration_jsp</servlet-name>
+        <url-pattern>/secure/edit/configuration.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
-        <url-pattern>/secure/details/benchmark.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
-        <url-pattern>/secure/edit/benchmark.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
-        <url-pattern>/secure/edit/processor.jsp</url-pattern>
-    </servlet-mapping>
-
-    <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
-        <url-pattern>/secure/edit/processBenchmarks.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.explore.spaces_jsp</servlet-name>
+        <url-pattern>/secure/explore/spaces.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -786,8 +771,23 @@
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-name>
-        <url-pattern>/secure/edit/spacePermissions.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.details.benchmark_jsp</servlet-name>
+        <url-pattern>/secure/details/benchmark.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.resubmitPairs_jsp</servlet-name>
+        <url-pattern>/secure/edit/resubmitPairs.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.processBenchmarks_jsp</servlet-name>
+        <url-pattern>/secure/edit/processBenchmarks.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.benchmark_jsp</servlet-name>
+        <url-pattern>/secure/edit/benchmark.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
@@ -796,18 +796,28 @@
     </servlet-mapping>
 
     <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.processor_jsp</servlet-name>
+        <url-pattern>/secure/edit/processor.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org.apache.jsp.secure.edit.spacePermissions_jsp</servlet-name>
+        <url-pattern>/secure/edit/spacePermissions.jsp</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
         <servlet-name>org.apache.jsp.secure.edit.community_jsp</servlet-name>
         <url-pattern>/secure/edit/community.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.edit.queue_jsp</servlet-name>
-        <url-pattern>/secure/edit/queue.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.index_jsp</servlet-name>
+        <url-pattern>/secure/index.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>
-        <servlet-name>org.apache.jsp.secure.index_jsp</servlet-name>
-        <url-pattern>/secure/index.jsp</url-pattern>
+        <servlet-name>org.apache.jsp.secure.edit.queue_jsp</servlet-name>
+        <url-pattern>/secure/edit/queue.jsp</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/WebContent/js/explore/cluster.js
+++ b/WebContent/js/explore/cluster.js
@@ -321,6 +321,7 @@ function getDetails(id, type, parent_node) {
 				10000);
 		}
 		$("#detailField .expdContainer").css("display", "none");
+		$("#descriptionContainer").show();
 	} else if (type == 'enabled_node' || type == 'disabled_node') {
 		$("#clusterExpd").html("<span class='list-count'/> Running Job Pairs");
 		$("#jobsContainer").hide();
@@ -332,6 +333,8 @@ function getDetails(id, type, parent_node) {
 			delete star.JobTableRefresh;
 		}
 		$("#detailField .expdContainer").css("display", "block");
+		//hide the queue desc
+		$("#descriptionContainer").hide();
 	} else {
 		showMessage('error', "Invalid node type", 5000);
 		return;

--- a/src/org/starexec/data/database/Statistics.java
+++ b/src/org/starexec/data/database/Statistics.java
@@ -102,6 +102,13 @@ public class Statistics {
 			for(Queue q : Queues.getQueues(-2)) {
 				numNodes += Queues.getNodes(q.getId()).size();
 			}
+			if (numNodes == 0) {
+				/*if we have no nodes, R.NODE_MULTIPLIER * numNodes * 1.1 will be 0.
+				This will cause an exception to be raised by setRange. To prevent it,
+				we return instantly.
+				*/
+				return;
+			}
 			plot.getRangeAxis().setRange(new Range(0, R.NODE_MULTIPLIER * numNodes * 1.1));
 
 			plot.getDomainAxis().setLabelPaint(new Color(255, 255, 255));
@@ -122,7 +129,7 @@ public class Statistics {
 			ChartUtilities.saveChartAsPNG(output, chart, 400, 400);
 			log.debug( "Finished chart making!: \n" + path.toString() + "/" + qId + "_queuegraph.png" );
 		} catch(Exception e) {
-			log.error("Error creating queue chart for "+Queues.getNameById(qId)+" ("+qId+")", e);
+			log.error("Error creating queue chart for "+Queues.getNameById(qId)+" ("+qId+"): " + e.getMessage());
 		}
 	}
 


### PR DESCRIPTION
This fixes the error below, if we have no nodes, just return to prevent this exception from being raised on the next line. If this exception gets raised, no chart gets created either way.

24 Jul 12:12:19.138      pool-271-thread-1 [ERROR] - Error creating queue chart for all.q (1): A positive range length is required: Range[0.0,0.0]


See the open source repo [here](https://github.com/jfree/jfreechart/blob/master/src/main/java/org/jfree/chart/axis/ValueAxis.java) and ctrl f for "A positive range length"

On the cluster page, when a node is selected, it hides the queue description. When a queue is selected, it shows the queue description.