### PR TITLE
Update LocalBackend.java

### DIFF
--- a/src/org/starexec/backend/LocalBackend.java
+++ b/src/org/starexec/backend/LocalBackend.java
@@ -78,7 +78,6 @@ public class LocalBackend implements Backend {
 	 */
 	private void runJob(LocalJob j){
 		try {
-			j.process = Util.executeCommandAndReturnProcess(new String[] {j.scriptPath}, null, new File(j.workingDirectoryPath));
 	    	ProcessBuilder builder = new ProcessBuilder(j.scriptPath);
 	    	builder.redirectErrorStream(true);
 	    	builder.directory(new File(j.workingDirectoryPath));


### PR DESCRIPTION
I removed a line in runJob in local backend.
The line was causing the job to be run twice.
I encountered this when trying to run jobs in our dockerized version of starexec (It uses the local backend).
It was causing the job to run and then also have an error that it wasn't able to run because it couldn't access the sandbox that it was already running in.